### PR TITLE
Update Travis config (node.js versions)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: node_js
 
 node_js:
-  - "0.12"
-  - "iojs"
+  - "8"
+  - "9"
 
 services:
   - redis-server
-
-before_install:
-  - '[ "${TRAVIS_NODE_VERSION}" != "0.8" ] || npm install -g npm@~1.4.0'


### PR DESCRIPTION
This updates the CI config to test on both node.js LTS and Current (8 and 9), instead of super outdated 0.12 and iojs. Unfortunately, there are quite some failing specs at the moment.

@lesion did you actually run and/or update the specs during merging all that code? I see a ton of changesets since the last commit before the forks.

closes #5