### PR TITLE
Update project name in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "restore",
+  "name": "armadietto",
   "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
The package-lock still lists reStore as the project name