### PR TITLE
replace async dependency with native javascript

### DIFF
--- a/lib/stores/file_tree.js
+++ b/lib/stores/file_tree.js
@@ -1,13 +1,12 @@
 'use strict';
 
-var async    = require('async'),
-    core     = require('./core'),
-    fs       = require('fs'),
-    lockfile = require('lockfile'),
-    mkdirp   = require('mkdirp'),
-    path     = require('path'),
-    rename   = require('./rename'),
-    util     = require('util');
+const core     = require('./core'),
+      fs       = require('fs'),
+      lockfile = require('lockfile'),
+      mkdirp   = require('mkdirp'),
+      path     = require('path'),
+      rename   = require('./rename'),
+      util     = require('util');
 
 var FileTree = function(options) {
   this._dir = path.resolve(options.path);
@@ -185,9 +184,14 @@ FileTree.prototype.get = function(username, path, version, callback) {
             return callback(null, null);
           }
           entries = entries.filter(function(e) { return !/^\.~/.test(e) });
-          async.map(entries, function(entry, callback) {
-            self._getListing(username, path, entry, callback);
-          }, function(error, listing) {
+          Promise.all(entries.map((entry) => {
+            return new Promise((resolve, reject) => {
+              self._getListing(username, path, entry, (error, listing) => {
+                if (error) reject(error);
+                else resolve(listing)
+              });
+            });
+          })).then((listing) => {
             release();
             callback(null, {children: listing, modified: mtime}, self._versionMatch(version, mtime));
           });
@@ -230,30 +234,98 @@ FileTree.prototype.put = function(username, pathname, type, value, version, call
     var dataPath = path.join(self._dir, self.dataPath(username, pathname)),
         metaPath = path.join(self._dir, self.metaPath(username, pathname));
 
-    self.getCurrentState(dataPath, version, function(error, current) {
+    self.getCurrentState(dataPath, version, async (error, current) => {
       if (error || !current) {
         release();
         return callback(error, null, null, true);
       }
-      async.waterfall([
-        function(next) {
-          self.writeBlob(metaPath, JSON.stringify({length: value.length, type: type}, true, 2), next);
-        },
-        function(exists, modified, next) {
-          self.writeBlob(dataPath, value, next);
-        },
-        function(exists, modified, next) {
-          async.forEach(core.indexed(query), function(entry, done) {
-            var q = entry.value, i = entry.index;
-            self.touch(self.dirname(username, query.slice(0, i+1).join('')), modified, done);
-          }, function() {
-            next(null, exists, modified);
+
+      try {
+        let exists, modified;
+
+        [exists, modified] = await new Promise((resolve, reject) => {
+          self.writeBlob(metaPath, JSON.stringify({length: value.length, type: type}, true, 2), (error, exists, modified) => {
+            if (error) reject(error);
+            else resolve([exists, modified]);
           });
-        }
-      ], function(error, exists, modified) {
+        });
+
+        [exists, modified] = await new Promise((resolve, reject) => {
+          self.writeBlob(dataPath, value, (error, exists, modified) => {
+            if (error) reject(error);
+            else resolve([exists, modified]);
+          });
+        });
+
+        [exists, modified] = await new Promise((resolve, reject) => {
+          // touch all entries in parallel
+          Promise.all(core.indexed(query).map((entry) => {
+            return new Promise((resolve, reject) => {
+              var q = entry.value, i = entry.index;
+              self.touch(self.dirname(username, query.slice(0, i+1).join('')), modified, (error) => {
+                if (error) reject(error);
+                else resolve();
+              });
+            })
+          })).then(() => {
+            if (error) reject(error);
+            else resolve([exists, modified]);
+          });
+        });
+
+        release();
+        callback(null, !exists, modified);
+
+      } catch(error) {
         release();
         callback(error, !exists, modified);
-      });
+      }
+
+      //
+      // let blobResults = {exists: null, modified: null};
+      // const assignBlobResults = (error, exists, modified) => {
+      //   if (error) {
+      //     release();
+      //     callback(error, !blobResults.exists, blobResults.modified);
+      //   } else {
+      //     blobResults.exists = exists;
+      //     blobResults.modified = modified;
+      //   }
+      // }
+      //
+      // new Promise((resolve) => {
+      //   self.writeBlob(metaPath, JSON.stringify({length: value.length, type: type}, true, 2), (error, exists, modified) => {
+      //     resolve(assignBlobResults(error, exists, modified))
+      //   })
+      // }).then(() => {
+      //   new Promise((resolve) => {
+      //     self.writeBlob(dataPath, value, (error, exists, modified) => {
+      //       resolve(assignBlobResults(error, exists, modified))
+      //     });
+      //   }).then(() => {
+      //     new Promise((resolve, reject) => {
+      //       // touch all entries in parallel
+      //       Promise.all(core.indexed(query).map((entry) => {
+      //         return new Promise((resolve, reject) => {
+      //           var q = entry.value, i = entry.index;
+      //           self.touch(self.dirname(username, query.slice(0, i+1).join('')), blobResults.modified, (error) => {
+      //             if (error) reject(error);
+      //             else resolve();
+      //           });
+      //         })
+      //       })).then(() => {
+      //         resolve(assignBlobResults(null, blobResults.exists, blobResults.modified));
+      //       });
+      //     });
+      //   }).then(() => {
+      //     // all errors should have been handled by this point
+      //     release();
+      //     callback(null, !blobResults.exists, blobResults.modified);
+      //   });
+      // }).catch((error) => {
+      //   release();
+      //   callback(error, !blobResults.exists, blobResults.modified);
+      // });
     });
   });
 };
@@ -292,24 +364,29 @@ FileTree.prototype._delete = function(username, pathname, version, callback) {
   });
 };
 
-FileTree.prototype._removeParents = function(username, pathname, callback) {
-  var self     = this,
-      query    = core.parsePath(pathname),
-      filename = query.pop(),
-      parents  = core.parents(pathname);
+FileTree.prototype._removeParents = async function(username, pathname, callback) {
+  const self      = this,
+        query     = core.parsePath(pathname),
+        filename  = query.pop(),
+        parents   = core.parents(pathname);
 
-  async.forEachSeries(parents, function(parent, done) {
-    var dirname = self.dirname(username, parent);
+  let dirname;
+  for (let parent of parents) {
+    dirname = self.dirname(username, parent);
 
-    self.childPaths(username, parent, function(entries) {
-      if (entries.length === 0) {
-        fs.rmdir(dirname, done);
-      } else {
-        var modified = new Date();
-        self.touch(dirname, modified.getTime(), done);
-      }
+    await new Promise((resolve) => {
+      self.childPaths(username, parent, (entries) => {
+        if (entries.length === 0) {
+          fs.rmdir(dirname, resolve);
+        } else {
+          var modified = new Date();
+          self.touch(dirname, modified.getTime(), resolve);
+        }
+      });
     });
-  }, callback);
+  }
+
+  callback();
 };
 
 FileTree.prototype.readFile = function(filename, callback) {

--- a/lib/stores/file_tree.js
+++ b/lib/stores/file_tree.js
@@ -280,52 +280,6 @@ FileTree.prototype.put = function(username, pathname, type, value, version, call
         release();
         callback(error, !exists, modified);
       }
-
-      //
-      // let blobResults = {exists: null, modified: null};
-      // const assignBlobResults = (error, exists, modified) => {
-      //   if (error) {
-      //     release();
-      //     callback(error, !blobResults.exists, blobResults.modified);
-      //   } else {
-      //     blobResults.exists = exists;
-      //     blobResults.modified = modified;
-      //   }
-      // }
-      //
-      // new Promise((resolve) => {
-      //   self.writeBlob(metaPath, JSON.stringify({length: value.length, type: type}, true, 2), (error, exists, modified) => {
-      //     resolve(assignBlobResults(error, exists, modified))
-      //   })
-      // }).then(() => {
-      //   new Promise((resolve) => {
-      //     self.writeBlob(dataPath, value, (error, exists, modified) => {
-      //       resolve(assignBlobResults(error, exists, modified))
-      //     });
-      //   }).then(() => {
-      //     new Promise((resolve, reject) => {
-      //       // touch all entries in parallel
-      //       Promise.all(core.indexed(query).map((entry) => {
-      //         return new Promise((resolve, reject) => {
-      //           var q = entry.value, i = entry.index;
-      //           self.touch(self.dirname(username, query.slice(0, i+1).join('')), blobResults.modified, (error) => {
-      //             if (error) reject(error);
-      //             else resolve();
-      //           });
-      //         })
-      //       })).then(() => {
-      //         resolve(assignBlobResults(null, blobResults.exists, blobResults.modified));
-      //       });
-      //     });
-      //   }).then(() => {
-      //     // all errors should have been handled by this point
-      //     release();
-      //     callback(null, !blobResults.exists, blobResults.modified);
-      //   });
-      // }).catch((error) => {
-      //   release();
-      //   callback(error, !blobResults.exists, blobResults.modified);
-      // });
     });
   });
 };

--- a/lib/stores/redis.js
+++ b/lib/stores/redis.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var async = require('async'),
-    core  = require('./core');
+const core = require('./core');
 
 var RedisStore = function(options) {
   this._options = options || {};
@@ -132,17 +131,19 @@ RedisStore.prototype.revokeAccess = function(username, token, callback) {
 };
 
 RedisStore.prototype.permissions = function(username, token, callback) {
-  var self   = this,
-      output = {},
-      client = this.redisFor(username);
+  const self   = this,
+        output = {},
+        client = self.redisFor(username);
 
-  client.smembers(self.permissionPath(username, token), function(error, categories) {
-    async.forEach(categories, function(dir, next) {
-      client.smembers(self.permissionPath(username, token, dir), function(error, permissions) {
-        output[dir.replace(/^\/?/, '/').replace(/\/?$/, '/')] = permissions.sort();
-        next();
+  client.smembers(self.permissionPath(username, token), (error, categories) => {
+    Promise.all(categories.map((dir) => {
+      return new Promise((resolve, reject) => {
+        client.smembers(self.permissionPath(username, token, dir), (error, permissions) => {
+          output[dir.replace(/^\/?/, '/').replace(/\/?$/, '/')] = permissions.sort();
+          resolve();
+        });
       });
-    }, function() {
+    })).then(() => {
       callback(null, output);
     });
   });
@@ -182,13 +183,22 @@ RedisStore.prototype.get = function(username, pathname, version, callback) {
             release();
             return callback(null, null);
           }
-          async.map(children.sort(), function(child, callback) {
-            client.hget(key + child, 'modified', function(error, modified) {
-              callback(error, {name: child, modified: parseInt(modified, 10)});
+          Promise.all(children.sort().map((child) => {
+            return new Promise((resolve, reject) => {
+              client.hget(key + child, 'modified', function(error, modified) {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve({name: child, modified: parseInt(modified, 10)});
+                }
+              });
             });
-          }, function(error, listing) {
+          })).then((listing) => {
             release();
             callback(null, {children: listing, modified: modified}, self._versionMatch(version, modified));
+          }).catch((error) => {
+            release();
+            callback(error);
           });
         });
       });
@@ -247,31 +257,44 @@ RedisStore.prototype.delete = function(username, pathname, version, callback) {
       dataKey = prefix + pathname;
 
   this._lock(username, function(release) {
-    self.getCurrentState(client, dataKey, version, function(error, current, mtime) {
+    self.getCurrentState(client, dataKey, version, async (error, current, mtime) => {
       if (error || !current) {
         release();
         return callback(error, false, null, !current);
       }
 
-      async.waterfall([
-        function(next) {
-          async.map(parents, function(parent, callback) {
-            client.smembers(prefix + parent + ':children', callback);
-          }, next);
-        }, function(children, next) {
-          var empty = [], index = 0, remaining;
+      try {
+        const children = await new Promise((resolve, reject) => {
+          Promise.all(parents.map((parent) => {
+            return new Promise((resolve) => {
+              client.smembers(prefix + parent + ':children', (error, child) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve(child);
+                }
+              });
+            });
+          })).then((children) => {
+            resolve(children);
+          });
+        });
+
+        const [empty, remaining] = await new Promise((resolve) => {
+          let empty = [],
+              index = 0,
+              remaining;
 
           while (index < parents.length && children[index].length === 1) {
             empty.push(parents[index]);
             index += 1;
           }
-
           remaining = parents.slice(index);
+          resolve([empty, remaining]);
+        });
 
-          next(error, index, empty, remaining);
-
-        }, function(index, empty, remaining, next) {
-          var multi    = client.multi(),
+        await new Promise((resolve) => {
+          let multi    = client.multi(),
               modified = new Date().getTime().toString().replace(/...$/, '000'),
               item;
 
@@ -291,12 +314,15 @@ RedisStore.prototype.delete = function(username, pathname, version, callback) {
           });
 
           multi.del(dataKey);
-          multi.exec(next);
-        }
-      ], function(error) {
+          multi.exec(resolve);
+        });
+
+        release();
+        callback(null, !!mtime, mtime);
+      } catch(error) {
         release();
         callback(error, !!mtime, mtime);
-      });
+      }
     });
   });
 };

--- a/lib/stores/rename.js
+++ b/lib/stores/rename.js
@@ -1,8 +1,7 @@
 'use strict';
 
-var fs    = require('fs'),
-    path  = require('path'),
-    async = require('async');
+const fs    = require('fs'),
+      path  = require('path');
 
 var rename = function(pathname, pattern, replacement, callback) {
   var dirname  = path.dirname(pathname),
@@ -23,10 +22,12 @@ var traverse = function(pathname, root, pattern, replacement, callback) {
     if (stat.isFile()) return rename(pathname, pattern, replacement, callback);
     if (!stat.isDirectory()) return callback(new Error());
 
-    fs.readdir(pathname, function(error, entries) {
-      async.forEach(entries, function(entry, next) {
-        traverse(path.join(pathname, entry), false, pattern, replacement, next);
-      }, function(error) {
+    fs.readdir(pathname, (error, entries) => {
+      Promise.all(entries.map((entry) => {
+        return new Promise((resolve, reject) => {
+          traverse(path.join(pathname, entry), false, pattern, replacement, resolve);
+        });
+      })).then((error) => {
         if (error) return callback(error);
         if (root) return callback();
         rename(pathname, pattern, replacement, callback);
@@ -35,10 +36,13 @@ var traverse = function(pathname, root, pattern, replacement, callback) {
   });
 };
 
-var batchRename = function(pathname, renames, callback) {
-  async.forEachSeries(renames, function(pair, next) {
-    traverse(pathname, true, pair[0], pair[1], next);
-  }, callback);
+var batchRename = async function(pathname, renames, callback) {
+  for (let pair of renames) {
+    await new Promise((resolve) => {
+      traverse(pathname, true, pair[0], pair[1], resolve);
+    });
+  }
+  callback();
 };
 
 module.exports = batchRename;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "restore",
+  "name": "armadietto",
   "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -17,23 +17,15 @@
         "sprintf-js": "1.0.3"
       }
     },
-    "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -100,16 +92,16 @@
       "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -187,9 +179,9 @@
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "version": "0.3.0",
   "engines": {
-    "node": ">=6.11.0"
+    "node": ">=7.6.0"
   },
   "bin": {
     "armadietto": "./bin/server.js"
@@ -20,7 +20,6 @@
   "main": "./lib/armadietto.js",
   "dependencies": {
     "argparse": "^1.0.7",
-    "async": "",
     "ejs": ">= 2.0.0",
     "lockfile": ">= 1.0.0",
     "mkdirp": "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,31 @@
 # yarn lockfile v1
 
 
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  dependencies:
+    sprintf-js "~1.0.2"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
 double-ended-queue@^2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
@@ -10,9 +35,89 @@ double-ended-queue@^2.1.0-0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+glob@^7.0.5:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+jstest@:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/jstest/-/jstest-1.0.5.tgz#e09da1e1d6a1c28b63afd952d3dd7a98c5d86027"
+  dependencies:
+    nopt ""
+
 "lockfile@>= 1.0.0":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.3.tgz#2638fc39a0331e9cac1a04b71799931c9c50df79"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+mkdirp@:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
+nopt@:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+  dependencies:
+    abbrev "1"
+    osenv "^0.1.4"
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  dependencies:
+    wrappy "1"
+
+os-homedir@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+
+os-tmpdir@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+
+osenv@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.0"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
 redis-commands@^1.2.0:
   version "1.3.1"
@@ -29,3 +134,17 @@ redis-parser@^2.6.0:
     double-ended-queue "^2.1.0-0"
     redis-commands "^1.2.0"
     redis-parser "^2.6.0"
+
+rimraf@:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
fixes #2

Note that due to the native async functions and `Promise` API I'm using here, we have to bump up the required Node version to >=7.6.0. I don't think this should be a big issue since 8 is the current LTS series.

Also included, while removing `async`, npm and yarn did some updating of
their lockfiles.