### PR TITLE
update GitHub org name in package.json to remotestorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "armadietto",
   "description": "Simple remoteStorage server",
-  "homepage": "http://github.com/jcoglan/armadietto",
+  "homepage": "http://github.com/remotestorage/armadietto",
   "author": "James Coglan <jcoglan@gmail.com> (http://jcoglan.com/)",
   "keywords": [
     "remoteStorage",
@@ -35,9 +35,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/jcoglan/armadietto.git"
+    "url": "git://github.com/remotestorage/armadietto.git"
   },
   "bugs": {
-    "url": "http://github.com/jcoglan/armadietto/issues"
+    "url": "http://github.com/remotestorage/armadietto/issues"
   }
 }


### PR DESCRIPTION
The previous links would have 404'd. I'm concerned about this in case we publish to npm once it's ready (which I think we should).

Question: What should we do about the author field? I know remoteStorage.js doesn't have one at all, and that might be the solution.