### PR TITLE
Display all authenticated apps for a user on their account page

### DIFF
--- a/lib/armadietto.js
+++ b/lib/armadietto.js
@@ -153,6 +153,12 @@ class Armadietto {
       if (method === 'POST') return users.register();
     }
 
+    if (uri.pathname === 'account') {
+      const users = new Users(this, req, res);
+      if (method === 'GET') return users.showLoginForm();
+      if (method === 'POST') return users.showAccountPage();
+    }
+
     match = uri.pathname.match(/^storage\/([^/]+)(.*)$/);
     if (match) {
       const username = decodeURIComponent(match[1]).split('@')[0];

--- a/lib/assets/style.css
+++ b/lib/assets/style.css
@@ -120,3 +120,16 @@ th, td {
 input {
   font: 0.8em Open Sans, FreeSans, Helvetica, Arial, sans-serif;
 }
+.deemphasize {
+	color: #a6a6a6;
+	font-size: 0.8em;
+}
+.favicon {
+	width: 32px;
+	height: 32px;
+	vertical-align: middle;
+}
+
+.account-info td {
+	font-size: 0.8em;
+}

--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -18,6 +18,62 @@ class Users extends Controller {
       this.renderHTML(409, 'signup.html', { params: this.params, error });
     }
   }
+
+  async showLoginForm () {
+    if (this.redirectToSSL()) return;
+    this.renderHTML(200, 'login.html', { params: this.params, error: null });
+  }
+
+  async showAccountPage () {
+    if (this.blockUnsecureRequest()) return;
+
+    const expandedPermissions = {
+      'r': 'Read',
+      'w': 'Write'
+    };
+
+    try {
+      await this.server._store.authenticate(this.params);
+      const authData = await this.server._store.readAuth(this.params.username);
+      // this is a bit of a monster but it formats the somewhat unwieldy auth.json
+      // for a user into something that looks like:
+      // {
+      //   "params": {"username": string},
+      //   "host": string,
+      //   "sessions: [
+      //     "clientId": string,    <- the url for the app as per the spec
+      //     "permissions": [
+      //       {
+      //         "folder": string,
+      //         "permissions": ["Read", "Write"]    <- the permission array may contain one/both
+      //       }
+      //     ]
+      //   ]
+      // }
+      //
+      // We're doing this transform just to make it easier on the view side to
+      // iterate over things.
+      this.renderHTML(200, 'account.html', {
+        params: { username: this.params.username },
+        host: this.getHost(),
+        sessions: authData.sessions ? Object.keys(authData.sessions).map(k => {
+          return {
+            clientId: authData.sessions[k].clientId,
+            permissions: Object.keys(authData.sessions[k].permissions).map(folder => {
+              return {
+                folder: folder,
+                permissions: Object.keys(authData.sessions[k].permissions[folder]).filter(perm => {
+                  return authData.sessions[k].permissions[folder][perm];
+                }).map(v => expandedPermissions[v])
+              };
+            })
+          };
+        }) : []
+      });
+    } catch (error) {
+      this.renderHTML(409, 'login.html', { params: this.params, error });
+    }
+  }
 }
 
 module.exports = Users;

--- a/lib/views/account.html
+++ b/lib/views/account.html
@@ -1,0 +1,29 @@
+<h2>Account Info</h2>
+
+<p>Your storage account: <%= params.username %>@<%= host %></p>
+
+<table class="account-info">
+	<thead>
+		<tr>
+			<th>Application</th>
+			<th>Permissions</th>
+		</tr>
+	</thead>
+	<tbody>
+	<% sessions.forEach(function(session) { %>
+		<tr>
+			<td>
+				<img src="<%= session.clientId %>/favicon.ico" alt="Favicon for <%= session.clientId %>" class="favicon">
+				<a href="<%= session.clientId %>" target="_blank"><%= session.clientId %></a>
+			</td>
+			<td>
+				<% session.permissions.forEach(folder => { %>
+				<%= folder.folder %> <span class="deemphasize">
+					(<%= folder.permissions.join(', ') %>)
+				</span>
+				<% }); %>
+			</td>
+		</tr>
+	<% }); %>
+	</tbody>
+</table>

--- a/lib/views/layout.html
+++ b/lib/views/layout.html
@@ -15,6 +15,7 @@
 
         <ul class="nav">
           <li><a href="<%= basePath %>/">Home</a></li>
+		  <li><a href="<%= basePath %>/account">Account</a></li>
           <% if (signup) { %><li><a href="<%= basePath %>/signup">Sign up</a></li><% } %>
         </ul>
       </div>

--- a/lib/views/login.html
+++ b/lib/views/login.html
@@ -1,0 +1,19 @@
+<h2>Log In</h2>
+
+<form method="post" action="<%= basePath %>/account">
+  <% if (error) { %>
+    <p class="error"><%= error.message %></p>
+  <% } %>
+
+  <table>
+    <tr>
+      <th scope="row"><label for="username">Username</label></th>
+      <td><input type="text" id="username" name="username" value="<%= params.username || '' %>"></td>
+    </tr>
+    <tr>
+      <th scope="row"><label for="password">Password</label></th>
+      <td><input type="password" id="password" name="password" value=""></td>
+    </tr>
+  </table>
+  <p><input type="submit" value="Go"></p>
+</form>


### PR DESCRIPTION
I added a new "Account" link in the header that allows users to view
all the apps that they've approved on their armadietto server. It will
prompt them to log in with their username/password and then it will
display:
- Their account name (username@host)
- A table of all their approved apps, with info about what permissions
  it has requested

The link appears regardless of the signup option to allow the server
manager to view their data.

![Screen Shot 2021-05-18 at 5 10 10 PM](https://user-images.githubusercontent.com/28445/118723917-faf58200-b7fb-11eb-9f86-a2f2a54a8716.png)


Fixes: #44 