### PR TITLE
Use @next tag for eslint-config-standard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "chai-http": "^4.3.0",
         "chai-spies": "^1.0.0",
         "eslint": "^8.7.0",
-        "eslint-config-standard": "github:standard/eslint-config-standard#v17.0.0-0",
+        "eslint-config-standard": "^17.0.0-0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-n": "^14.0.0",
         "eslint-plugin-node": "^11.1.0",
@@ -3285,7 +3285,8 @@
     },
     "node_modules/eslint-config-standard": {
       "version": "17.0.0-0",
-      "resolved": "git+ssh://git@github.com/standard/eslint-config-standard.git#6adbf5ffdf4d969ad935e9980ecc7166b959ee01",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0-0.tgz",
+      "integrity": "sha512-sf9udec8fkLTnH82SmhZQ3E31e4eJaMW09Mt9fbN3OccXFtvSSbGrltpQgGFVooGHoIdiMzDfp6ZNFd+I6Ob+w==",
       "dev": true,
       "funding": [
         {
@@ -3301,7 +3302,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.0.1",
         "eslint-plugin-import": "^2.25.2",
@@ -12564,9 +12564,10 @@
       }
     },
     "eslint-config-standard": {
-      "version": "git+ssh://git@github.com/standard/eslint-config-standard.git#6adbf5ffdf4d969ad935e9980ecc7166b959ee01",
+      "version": "17.0.0-0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0-0.tgz",
+      "integrity": "sha512-sf9udec8fkLTnH82SmhZQ3E31e4eJaMW09Mt9fbN3OccXFtvSSbGrltpQgGFVooGHoIdiMzDfp6ZNFd+I6Ob+w==",
       "dev": true,
-      "from": "eslint-config-standard@github:standard/eslint-config-standard#v17.0.0-0",
       "requires": {}
     },
     "eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chai-http": "^4.3.0",
     "chai-spies": "^1.0.0",
     "eslint": "^8.7.0",
-    "eslint-config-standard": "github:standard/eslint-config-standard#v17.0.0-0",
+    "eslint-config-standard": "^17.0.0-0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-n": "^14.0.0",
     "eslint-plugin-node": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,8 +1510,9 @@
   optionalDependencies:
     "source-map" "~0.6.1"
 
-"eslint-config-standard@github:standard/eslint-config-standard#v17.0.0-0":
-  "resolved" "git+ssh://git@github.com/standard/eslint-config-standard.git#6adbf5ffdf4d969ad935e9980ecc7166b959ee01"
+"eslint-config-standard@^17.0.0-0":
+  "integrity" "sha512-sf9udec8fkLTnH82SmhZQ3E31e4eJaMW09Mt9fbN3OccXFtvSSbGrltpQgGFVooGHoIdiMzDfp6ZNFd+I6Ob+w=="
+  "resolved" "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0-0.tgz"
   "version" "17.0.0-0"
 
 "eslint-import-resolver-node@^0.3.6":


### PR DESCRIPTION
Using a "github:" link results in git+ssh URLs in the lockfiles, which prevents unauthenticated installs.