### PR TITLE
Add security headers to home, signup & auth pages

### DIFF
--- a/bin/test-suite.json
+++ b/bin/test-suite.json
@@ -3,7 +3,7 @@
   "storage_path": "./bin/test-suite-storage",
   "cache_views": true,
   "http": {
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "port": 8000
   }
 }

--- a/lib/controllers/assets.js
+++ b/lib/controllers/assets.js
@@ -16,7 +16,8 @@ class Assets extends Controller {
     if (content) {
       this.response.writeHead(200, {
         'Content-Length': content.length,
-        'Content-Type': type
+        'Content-Type': type,
+        'X-Content-Type-Options': 'nosniff'
       });
       this.response.end(content);
     } else {

--- a/lib/controllers/base.js
+++ b/lib/controllers/base.js
@@ -23,7 +23,7 @@ class Controller {
 
   blockUnsecureRequest () {
     if (this.request.secure || !this.server._forceSSL) return false;
-    this.response.writeHead(400, { 'Strict-Transport-Security': 'max-age=86400' });
+    this.response.writeHead(400, { 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload' });
     this.response.end();
     return true;
   }
@@ -42,7 +42,7 @@ class Controller {
 
     this.response.writeHead(302, {
       Location: 'https://' + host + this.request.url,
-      'Strict-Transport-Security': 'max-age=86400'
+      'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload'
     });
     this.response.end();
     return true;
@@ -111,10 +111,17 @@ class Controller {
     };
     const html = Buffer.from(ejs.render(layout, globals));
 
-    response.writeHead(status, {
+    const headers = {
       'Content-Length': html.length,
-      'Content-Type': 'text/html'
-    });
+      'Content-Type': 'text/html',
+      'Content-Security-Policy': "sandbox allow-forms allow-same-origin; default-src 'self'; script-src 'none'; object-src 'none'; child-src 'none'; connect-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+      'X-Content-Type-Options': 'nosniff',
+      'Referrer-Policy': 'no-referrer'
+    };
+    if (this.server._forceSSL) {
+      headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains; preload';
+    }
+    response.writeHead(status, headers);
     response.end(html);
   }
 


### PR DESCRIPTION
The Content Security Policy (CSP) protects against malicious browser extensions, limits the damage of security breaches and makes the server a less-attractive target for hackers. The policy is to allow a server to load resources from itself and submit forms. The home, signup & auth pages don't use any other functionality, particularly execution of JavaScript in the browser. If and when we need more functionality, we can change the policy and thus make a conscious decision to expand our attack surface.

Strict Transport Security (HSTS) is enabled only if the https.force configuration is set. This rounds out an HTTPS-only site.

X-Content-Type-Options keeps browsers from being too clever and actually being stupid.

Referrer-Policy closes a privacy hole.

X-Frame-Options & X-XSS-Protection are obsoleted by the CSP and therefore not used.

These also moderately improve site rankings and reassure IT decision-makers.