### PR TITLE
Add release drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
Release Drafter automatically creates and updates release notes drafts from closed pull requests. When publishing a release, one only has to edit the draft to their taste, instead of assembling the whole document from scratch.