### PR TITLE
Improves success rate of rapid requests & also signals overload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm test
+      - run: npm run stresstest
 
   Conditional-Publish-to-NPM:
     needs: [Lint, Automated-Tests]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         # Support LTS versions based on https://nodejs.org/en/about/releases/
-        node-version: ['12', '14', '16']
+        node-version: ['14', '16', '18']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm test
-      - run: npm run stresstest
+      - run: npm run stresstest-node14
 
   Conditional-Publish-to-NPM:
     needs: [Lint, Automated-Tests]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm test
-      - run: npm run stresstest-node14
+      - run: npm run stress-test-auto
 
   Conditional-Publish-to-NPM:
     needs: [Lint, Automated-Tests]

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ master, stress-test ]
   pull_request:
-    branches: [ master, stress-test ]
 jobs:
   Lint:
     name: Lint

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master, stress-test ]
 jobs:
   Lint:
-    name: node.js
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
         run: npm run lint
 
   Automated-Tests:
-    name: node.js
+    name: Automated-Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,4 +37,4 @@ jobs:
       - name: Run tests
         run: npm test
       - name: Run stress tests
-        run: npm stresstest
+        run: npm run stresstest

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Run tests
         run: npm test
       - name: Run stress tests
-        run: npm run stresstest
+        run: npm run stresstest-node14

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Run tests
         run: npm test
       - name: Run stress tests
-        run: npm run stresstest-node14
+        run: npm run stress-test-auto

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -1,11 +1,25 @@
 name: test-and-lint
 on:
   push:
-    branches: [ master ]
+    branches: [ master, stress-test ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, stress-test ]
 jobs:
-  build:
+  Lint:
+    name: node.js
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm ci
+      - name: Run linter
+        run: npm run lint
+
+  Automated-Tests:
     name: node.js
     runs-on: ubuntu-latest
     strategy:
@@ -22,5 +36,5 @@ jobs:
         run: npm ci
       - name: Run tests
         run: npm test
-      - name: Run linter
-        run: npm run lint
+      - name: Run stress tests
+        run: npm stresstest

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ bin/test-suite-storage/rs/rs-test/storage
 test-log
 dev-log
 dev-storage
+stress-log
 .vscode
 .idea

--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ setup, you can set `https.force = true` but omit `https.port`; this means
 armadietto itself will not accept encrypted connections but will apply the above
 behaviour to enforce secure connections.
 
+## Stress Testing
+To test that an installation performs well under load, using node v16 or higher, run
+`SERVER_URL=https://myhostname USERNAME=existinguser PASSWORD=iloveyou npm run stresstest`,
+substituting your installation's origin, an existing user (preferably with no documents) and the user's password. If you don't define `SERVER_URL`, a server will be created locally, using the FileTree store.
+
+It's best to test using a machine on the same local network, to avoid bandwidth limitations and triggering abuse detection.
+
+If you get a failure on test 'returns "429 Too Many Requests" when a burst of puts or gets continues too long', edit `spec/stress/rapid_requests_spec.js` and increase `num` until the test doesn't fail (the server has been pushed to its limit).
+
 ## Storage backends
 
 armadietto supports pluggable storage backends, and comes with a file system

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ armadietto itself will not accept encrypted connections but will apply the above
 behaviour to enforce secure connections.
 
 ## Stress Testing
-To test that an installation performs well under load, using node v16 or higher, run
-`SERVER_URL=https://myhostname USERNAME=existinguser PASSWORD=iloveyou npm run stresstest`,
+To test that an installation performs well under load, using node v18 or higher, run
+`SERVER_URL=https://myhostname USERNAME=existinguser PASSWORD=iloveyou npm run stress-test`,
 substituting your installation's origin, an existing user (preferably with no documents) and the user's password. If you don't define `SERVER_URL`, a server will be created locally, using the FileTree store.
 
 It's best to test using a machine on the same local network, to avoid bandwidth limitations and triggering abuse detection.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ It's best to test using a machine on the same local network, to avoid bandwidth 
 
 If you get a failure on test 'returns "429 Too Many Requests" when a burst of puts or gets continues too long', edit `spec/stress/rapid_requests_spec.js` and increase `num` until the test doesn't fail (the server has been pushed to its limit).
 
+## Utility Functions
+To create a user, run `npm run create-user <username> <password>`.  Add the `-o` argument to set the origin (root URL) of the server, or `-e` to set the email.
+
+The server must already be running, and allow account creation.
+
 ## Storage backends
 
 armadietto supports pluggable storage backends, and comes with a file system

--- a/bin/create-user.js
+++ b/bin/create-user.js
@@ -1,0 +1,35 @@
+/* eslint-env node, browser */
+
+const yargs = require('yargs');
+
+const argv = yargs
+  .usage('Usage: $0 <username> <password>')
+  .demandCommand(2)
+  .option('email', { alias: 'e', description: "user's email", type: 'string', default: 'foo@example.com' })
+  .option('origin', { alias: 'o', description: 'base URL of the server', type: 'string', default: 'http://127.0.0.1:8000' })
+  .help()
+  .alias('help', 'h')
+  .argv;
+
+createUser(argv._[0], argv._[1], argv.email, argv.origin)
+  .catch(err => console.error(`error: ${err}`));
+
+async function createUser (username, password, email, origin) {
+  console.log(`creating user “${username}” ${email} at ${origin}`);
+  const signupUrl = new URL('signup', origin);
+  signupUrl.searchParams.set('username', username);
+  signupUrl.searchParams.set('password', password);
+  signupUrl.searchParams.set('email', email);
+  // console.log(`signupUrl: ${signupUrl.href}`);
+  const response = await fetch(signupUrl, {
+    method: 'POST'
+  });
+  if (response.ok) {
+    console.log(`${response.status} ${response.statusText}`);
+    // console.log(`${response.status} ${response.statusText} ${await response.text()}`);
+  } else {
+    console.error(`${response.status} ${response.statusText}`);
+    // console.error(`${response.status} ${response.statusText} ${await response.text()}`);
+  }
+  return response.status;
+}

--- a/bin/measure.js
+++ b/bin/measure.js
@@ -1,0 +1,184 @@
+/* eslint-env node, browser */
+
+const yargs = require('yargs');
+const { userDbName, delay } = require('../spec/util/test_util_node14');
+const { streamFactory } = require('../spec/util/test_util');
+
+const clientId = 'http://example.com';
+
+const argv = yargs
+  .option('origin', {
+    alias: 'o',
+    description: 'base URL of the server',
+    type: 'string',
+    default: process.env.SERVER_URL || 'http://127.0.0.1:8000'
+  })
+  .option('size', {
+    alias: 's',
+    description: 'size (in bytes) of rapid requests',
+    type: 'number',
+    default: 4000
+  })
+  .option('delay', {
+    alias: 'd',
+    description: 'how long (in ms) to wait between requests',
+    type: 'number',
+    default: 10
+  })
+  .option('max', {
+    alias: 'm',
+    description: 'maximum number of requests',
+    type: 'number',
+    default: 2000
+  })
+  .option('username', {
+    alias: 'u',
+    description: 'name of user',
+    type: 'string',
+    default: process.env.USERNAME || 'stressuser'
+  })
+  .option('password', {
+    alias: 'p',
+    description: 'password of user',
+    type: 'string',
+    default: process.env.PASSWORD || 'kladljkfdsoi983'
+  })
+  .help()
+  .alias('help', 'h')
+  .argv;
+
+measure(argv.origin, argv.size, argv.delay, argv.max, argv.username, argv.password)
+  .then(result => {
+    console.info(`first failure: ${result.firstFailure}   longest run length: ${result.longestRunLength}   num: ${result.num}`);
+    console.info(`delete time: ${result.deleteTimeNs / 1_000_000_000} s   create time: ${result.createTimeNs / 1_000_000_000} s`);
+    // console.log(`statuses: ${result.statuses}`)
+  })
+  .catch(err => console.error('error:', err));
+
+async function measure (origin, size, delayMs, max, username, password) {
+  const url = new URL('/oauth', origin).href;
+  const param = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: clientId + '/',
+    response_type: 'token',
+    state: '5d0176aa',
+    scope: '/:rw',
+    username,
+    password,
+    allow: 'Allow'
+  });
+  console.info(`logging in to ${url} username “${username}” scope “/:rw”`);
+  const resp = await fetch(url, { method: 'POST', body: param });
+  let token;
+  if (resp.redirected) {
+    const respUrl = new URL(resp.url);
+    const respParam = new URLSearchParams(respUrl.hash.slice(1));
+    token = respParam.get('access_token');
+  } else {
+    if (resp.status === 401) {
+      throw new Error(`Does the password match the username? ${origin} ${resp.status} ${resp.statusText}`);
+    } else {
+      throw new Error(`${origin} didn't redirect; ${resp.status} ${resp.statusText} ${(await resp.text()).slice(0, 60)}`);
+    }
+  }
+  console.info(`using ${username} (CouchDB database ${userDbName(username)})`);
+
+  const directoryName = 'many';
+  const puts = [];
+  let firstFailure = Number.POSITIVE_INFINITY;
+  let deleteTimeNs, createStart;
+  try {
+    deleteTimeNs = await deleteAll(directoryName, max);
+
+    console.info(`creating ${max} documents of ${size} bytes in “${directoryName}” at ${delayMs} ms intervals`);
+    let i = 0;
+    createStart = process.hrtime.bigint();
+    do {
+      doPut(directoryName, i); // Intentionally doesn't await
+      await delay(delayMs);
+      ++i;
+    } while (firstFailure === Number.POSITIVE_INFINITY && i < max);
+
+    await Promise.allSettled(puts);
+  } catch (err) {
+    let msg = `while awaiting put of ${size} byte document\n    ${err.name}  ${err.code}  ${err.message}`;
+    if (err.cause) {
+      msg += ` -> ${err.cause?.name}  ${err.cause?.code}  ${err.cause?.message}`;
+    }
+    console.error(msg);
+  }
+  const createTimeNs = Number(process.hrtime.bigint() - createStart);
+
+  let runStart = 0;
+  let longestRunLength = 0;
+  let j = 0;
+  do {
+    if (puts[j] !== 200 && puts[j] !== 201) {
+      const thisRunLength = j - runStart;
+      if (thisRunLength > longestRunLength) {
+        longestRunLength = thisRunLength;
+      }
+      runStart = j + 1;
+    }
+    ++j;
+    if (j === puts.length) {
+      const thisRunLength = j - runStart;
+      if (thisRunLength > longestRunLength) {
+        longestRunLength = thisRunLength;
+      }
+    }
+  } while (j < puts.length);
+
+  return { firstFailure, longestRunLength, num: puts.length, statuses: puts, deleteTimeNs, createTimeNs };
+
+  async function doPut (directoryName, i) {
+    try {
+      const path = `/storage/${username}/${directoryName}/${i}`;
+      const promise = fetch(new URL(path, origin), {
+        method: 'PUT',
+        headers: { Authorization: 'Bearer ' + token, 'Content-Type': 'text/plain' },
+        body: streamFactory(size, i)
+      }
+      );
+      puts[i] = promise;
+      const result = await promise;
+      puts[i] = result.status;
+      if (!result.ok) {
+        if (i < firstFailure) {
+          firstFailure = i;
+        }
+        if (result.status !== 429) {
+          console.warn(`${i} ${result.status} ${result.statusText}`);
+        }
+      }
+    } catch (err) { // probably a network failure
+      puts[i] = err.cause?.name || err.cause?.code || err.cause?.message || err.name || err.code || err.message;
+      if (i < firstFailure) {
+        firstFailure = i;
+      }
+      console.warn(i, puts[i]);
+    }
+  }
+
+  async function deleteAll (directoryName, max) {
+    console.info(`deleting ${max} documents in “${directoryName}”`);
+    const deleteBegin = process.hrtime.bigint();
+    for (let i = 0; i < max; ++i) {
+      try {
+        const path = `/storage/${username}/${directoryName}/${i}`;
+        const result = await fetch(new URL(path, origin), {
+          method: 'DELETE',
+          headers: { Authorization: 'Bearer ' + token, 'Content-Type': 'text/plain' }
+        }
+        );
+        if (!result.ok && result.status !== 404) {
+          console.error(`Can't delete ${i}: ${result.status} ${result.statusText}`);
+        }
+      } catch (err) {
+        console.error(`Can't delete ${i}: ${err.cause?.name || err.cause?.code || err.cause?.message || err.name || err.code || err.message}`);
+      }
+    }
+
+    return Number(process.hrtime.bigint() - deleteBegin);
+  }
+}

--- a/lib/armadietto.js
+++ b/lib/armadietto.js
@@ -114,8 +114,6 @@ class Armadietto {
     if ((await this._server)._http) (await this._server)._http.close();
     if ((await this._server)._https) (await this._server)._https.close();
     getLogger().notice('No longer accepting remoteStorage connections');
-
-    // TODO: remove all file locks
   }
 
   handle (req, res) {

--- a/lib/controllers/base.js
+++ b/lib/controllers/base.js
@@ -53,7 +53,7 @@ class Controller {
 
   invalidUser (username) {
     if (core.isValidUsername(username)) return false;
-    this.response.writeHead(400, { 'Content-Type': 'text/plan' });
+    this.response.writeHead(400, { 'Content-Type': 'text/plain' });
     this.response.end();
     logRequest(this.request, username, 400, 0, 'invalid user');
     return true;

--- a/lib/controllers/base.js
+++ b/lib/controllers/base.js
@@ -55,7 +55,7 @@ class Controller {
     if (core.isValidUsername(username)) return false;
     this.response.writeHead(400, { 'Content-Type': 'text/plain' });
     this.response.end();
-    logRequest(this.request, username, 400, 0, 'invalid user');
+    logRequest(this.request, username, 400, 0, `invalid username “${username}”`);
     return true;
   }
 

--- a/lib/controllers/storage.js
+++ b/lib/controllers/storage.js
@@ -38,12 +38,19 @@ class Storage extends Controller {
       try {
         var { item, versionMatch } = await this.server._store.get(this._username, this._path, version, head);
       } catch (e) {
-        getLogger().error(`Your storage backend does not behave correctly => ${e.message}`);
-        this.response.writeHead(500, this._headers);
+        let status;
+        if (e.code === 'TOO_MANY_REQUESTS') {
+          status = 429;
+          this._headers['Retry-After'] = '15'; // TODO: dynamically calculate
+        } else {
+          status = 500;
+        }
+        this._headers['Content-Type'] = 'text/plain; charset=utf8';
+        this.response.writeHead(status, this._headers);
         this.response.write(e.message);
         this.response.end();
         numBytesWritten = e.message.length; // presumes message is ASCII
-        return logRequest(this.request, this._username, 500, numBytesWritten, e);
+        return logRequest(this.request, this._username, status, numBytesWritten, e);
       }
       const status = item ? 200 : 404;
 
@@ -98,8 +105,14 @@ class Storage extends Controller {
               ? 201
               : 200;
       } catch (e) {
+        if (e.code === 'TOO_MANY_REQUESTS') {
+          status = 429;
+          this._headers['Retry-After'] = '15'; // TODO: dynamically calculate
+        } else {
+          status = 500;
+        }
         error = e;
-        status = 500;
+        this._headers['Content-Type'] = 'text/plain; charset=utf8';
       }
       this.setVersion(modified);
       if (error) this._headers['Content-Length'] = Buffer.from(error.message).length;

--- a/lib/stores/file_tree.js
+++ b/lib/stores/file_tree.js
@@ -21,11 +21,15 @@ class FileTree {
   async _lock (username) {
     const lockPath = path.join(this._dir, username.substr(0, 2), username, '.lock');
     try {
-      await lock(lockPath, { wait: 200 });
+      await lock(lockPath, { wait: 30_000 }); // Firefox will wait 10 minutes, other browsers longer.
     } catch (e) {
-      const err = new Error('Locked !?!?' + e.toString());
-      getLogger().error('lock failed:', err);
-      throw err;
+      if (e.code === 'EEXIST') { // lock timed out
+        const err = new Error('Slow your request rate');
+        err.code = 'TOO_MANY_REQUESTS';
+        throw err;
+      } else {
+        throw e;
+      }
     }
   }
 

--- a/notes/reverse-proxy-configuration.md
+++ b/notes/reverse-proxy-configuration.md
@@ -1,8 +1,8 @@
 # Configuring Apache as a Reverse Proxy for Armadietto
 
-1. [optional] Set a DNS A record for a new domain name, if Armadietto will appear as a different host than other websites served by your reverse proxy.
-2. Ensure your TLS certificate includes the domain name Armadietto be will visible as.
-3. [optional] Set up a name-based virtual server, if Armadietto will appear as a different host than other websites served by your reverse proxy.
+1. [optional] Set a DNS A record for the new domain name, if you are setting up Armadietto on a new domain name.
+2. Ensure your TLS certificate includes the domain name Armadietto be will visible as. (If you don't yet have a certificate, [Let's Encrypt](https://letsencrypt.org/) is a good source.)
+3. [optional] Set up a name-based virtual server, if you are setting up Armadietto on a new domain name.
 4. Configure your reverse proxy, and have it set the header `x-forwarded-proto` (or `x-forwarded-ssl` or `x-forwarded-scheme`) in the request passed to Armadietto. (Armadietto does not yet support the `Forwarded` header.) The Apache directives are `ProxyPass`, `ProxyPassReverse`, and `RequestHeader`. If you set `timeout` on `ProxyPass`, or `ProxyTimeout`, set it to 30 seconds or more. A name-based virtual server and reverse proxy will resemble:
 ```
 <VirtualHost *:443>
@@ -52,3 +52,4 @@ server {
 5. Run `armadietto -e` to see a sample configuration file.
 6. Create a configuration file at `/etc/armadietto/conf` (or elsewhere). See README.md for values and their meanings.
 7. Run `armadietto -c /etc/armadietto/conf`
+8. [optional] On Linux systems not protected by CloudFlare, in the Fail2ban configuration files, enable all the predefined jails that start with `apache-`.

--- a/notes/reverse-proxy-configuration.md
+++ b/notes/reverse-proxy-configuration.md
@@ -1,9 +1,9 @@
-# Configuring a Reverse Proxy for Armadietto
+# Configuring Apache as a Reverse Proxy for Armadietto
 
 1. [optional] Set a DNS A record for a new domain name, if Armadietto will appear as a different host than other websites served by your reverse proxy.
 2. Ensure your TLS certificate includes the domain name Armadietto be will visible as.
 3. [optional] Set up a name-based virtual server, if Armadietto will appear as a different host than other websites served by your reverse proxy.
-4. Configure your reverse proxy, and have it set the header `x-forwarded-proto` (or `x-forwarded-ssl` or `x-forwarded-scheme`) in the request passed to Armadietto. Armadietto does not yet support the `Forwarded` header, nor the PROXY protocol. For Apache, the directives are `ProxyPass`, `ProxyPassReverse`, and `RequestHeader`. For Apache, a name-based virtual server and reverse proxy will resemble:
+4. Configure your reverse proxy, and have it set the header `x-forwarded-proto` (or `x-forwarded-ssl` or `x-forwarded-scheme`) in the request passed to Armadietto. (Armadietto does not yet support the `Forwarded` header.) The Apache directives are `ProxyPass`, `ProxyPassReverse`, and `RequestHeader`. If you set `timeout` on `ProxyPass`, or `ProxyTimeout`, set it to 30 seconds or more. A name-based virtual server and reverse proxy will resemble:
 ```
 <VirtualHost *:443>
 ServerName storage.example.com
@@ -13,7 +13,7 @@ SSLCertificateFile      /etc/letsencrypt/live/example.com/fullchain.pem
 SSLCertificateKeyFile   /etc/letsencrypt/live/example.com/privkey.pem
 SSLCertificateChainFile /etc/letsencrypt/live/example.com/fullchain.pem
 
-ProxyPass        "/"  "http://127.0.0.1:8000/" connectiontimeout=5 timeout=30
+ProxyPass        "/"  "http://127.0.0.1:8000/"
 ProxyPassReverse "/"  "http://127.0.0.1:8000/"
 RequestHeader set x-forwarded-proto "https"
 RequestHeader unset x-forwarded-ssl

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "ejs": "^3.1.6",
         "lockfile": "^1.0.4",
         "mkdirp": "^1.0.4",
-        "winston": "^3.5.1"
+        "winston": "^3.5.1",
+        "yargs": "^17.5.1"
       },
       "bin": {
         "armadietto": "bin/armadietto.js"
@@ -36,7 +37,7 @@
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": ">=12.x"
+        "node": ">=14.0"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -300,7 +301,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -755,7 +755,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1025,8 +1024,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/enabled": {
       "version": "2.0.0",
@@ -1097,7 +1095,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1966,7 +1963,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -2395,7 +2391,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3145,6 +3140,24 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mocha/node_modules/yargs-parser": {
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
@@ -3627,7 +3640,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3798,7 +3810,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3838,7 +3849,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4319,7 +4329,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4336,7 +4345,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4351,7 +4359,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4362,8 +4369,7 @@
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -4396,7 +4402,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -4408,30 +4413,28 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-unparser": {
@@ -4692,8 +4695,7 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -5015,7 +5017,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -5240,8 +5241,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "enabled": {
       "version": "2.0.0",
@@ -5299,8 +5299,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -5932,8 +5931,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -6239,8 +6237,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-glob": {
       "version": "4.0.3",
@@ -6774,6 +6771,21 @@
             "has-flag": "^4.0.0"
           }
         },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
         "yargs-parser": {
           "version": "20.2.4",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
@@ -7141,8 +7153,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "resolve": {
       "version": "1.21.0",
@@ -7278,7 +7289,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7309,7 +7319,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -7683,7 +7692,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7694,7 +7702,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -7703,7 +7710,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -7711,8 +7717,7 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         }
       }
     },
@@ -7743,8 +7748,7 @@
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
     "yallist": {
       "version": "4.0.0",
@@ -7753,25 +7757,23 @@
       "dev": true
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
       }
     },
     "yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     },
     "yargs-unparser": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "dev": "nodemon --inspect -w ./lib ./bin/armadietto.js -c ./bin/dev-conf.json",
     "test": "mocha -u bdd-lazy-var/getter  spec/runner.js",
+    "stresstest": "mocha -u bdd-lazy-var/getter  spec/stress_runner.js",
     "lint": "eslint \"lib/**/*.js\" \"bin/**/*.js\" \"spec/**/*.js\"",
     "lint:fix": "eslint --fix \"lib/**/*.js\" \"bin/**/*.js\" \"spec/**/*.js\""
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "scripts": {
     "dev": "nodemon --inspect -w ./lib ./bin/armadietto.js -c ./bin/dev-conf.json",
     "test": "mocha -u bdd-lazy-var/getter  spec/runner.js",
-    "stresstest": "mocha -u bdd-lazy-var/getter  spec/stress_runner.js",
+    "stresstest-node14": "mocha spec/stress_runner.js",
+    "stresstest": "node --experimental-fetch node_modules/mocha/bin/_mocha spec/stress_runner.js",
     "lint": "eslint \"lib/**/*.js\" \"bin/**/*.js\" \"spec/**/*.js\"",
     "lint:fix": "eslint --fix \"lib/**/*.js\" \"bin/**/*.js\" \"spec/**/*.js\""
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "ejs": "^3.1.6",
     "lockfile": "^1.0.4",
     "mkdirp": "^1.0.4",
-    "winston": "^3.5.1"
+    "winston": "^3.5.1",
+    "yargs": "^17.5.1"
   },
   "devDependencies": {
     "bdd-lazy-var": "^2.6.1",
@@ -48,6 +49,7 @@
   "scripts": {
     "dev": "nodemon --inspect -w ./lib ./bin/armadietto.js -c ./bin/dev-conf.json",
     "test": "mocha -u bdd-lazy-var/getter  spec/runner.js",
+    "create-user": "node --experimental-fetch ./bin/create-user.js",
     "stress-test-auto": "mocha spec/stress_runner_auto.js",
     "stress-test": "node --experimental-fetch node_modules/mocha/bin/_mocha spec/stress_runner.js",
     "lint": "eslint \"lib/**/*.js\" \"bin/**/*.js\" \"spec/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   "scripts": {
     "dev": "nodemon --inspect -w ./lib ./bin/armadietto.js -c ./bin/dev-conf.json",
     "test": "mocha -u bdd-lazy-var/getter  spec/runner.js",
-    "stresstest-node14": "mocha spec/stress_runner.js",
-    "stresstest": "node --experimental-fetch node_modules/mocha/bin/_mocha spec/stress_runner.js",
+    "stress-test-auto": "mocha spec/stress_runner_auto.js",
+    "stress-test": "node --experimental-fetch node_modules/mocha/bin/_mocha spec/stress_runner.js",
     "lint": "eslint \"lib/**/*.js\" \"bin/**/*.js\" \"spec/**/*.js\"",
     "lint:fix": "eslint --fix \"lib/**/*.js\" \"bin/**/*.js\" \"spec/**/*.js\""
   },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "dev": "nodemon --inspect -w ./lib ./bin/armadietto.js -c ./bin/dev-conf.json",
     "test": "mocha -u bdd-lazy-var/getter  spec/runner.js",
     "create-user": "node --experimental-fetch ./bin/create-user.js",
+    "measure": "node --experimental-fetch ./bin/measure.js",
     "stress-test-auto": "mocha spec/stress_runner_auto.js",
     "stress-test": "node --experimental-fetch node_modules/mocha/bin/_mocha spec/stress_runner.js",
     "lint": "eslint \"lib/**/*.js\" \"bin/**/*.js\" \"spec/**/*.js\"",

--- a/spec/couchDbOptions.json
+++ b/spec/couchDbOptions.json
@@ -1,0 +1,7 @@
+{
+  "urlXXX": "https://couch3.tklapp.com:7000/",
+  "userAdminXXX": "admin",
+  "passwordAdminXXX": "di8hig3dea",
+  "userAdmin": "operator",
+  "passwordAdmin": "34muf28lop56"
+}

--- a/spec/couchDbOptions.json
+++ b/spec/couchDbOptions.json
@@ -1,7 +1,0 @@
-{
-  "urlXXX": "https://couch3.tklapp.com:7000/",
-  "userAdminXXX": "admin",
-  "passwordAdminXXX": "di8hig3dea",
-  "userAdmin": "operator",
-  "passwordAdmin": "34muf28lop56"
-}

--- a/spec/stress/rapid_requests_node14_spec.js
+++ b/spec/stress/rapid_requests_node14_spec.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-unused-expressions */
 
 const os = require('os');
+const { userDbName, delay } = require('../util/test_util_node14');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 const expect = chai.expect;
@@ -19,10 +20,6 @@ const clientId = 'http://example.com';
 
 const req = chai.request(host);
 process.umask(0o077);
-
-function userDbName (username) {
-  return 'userdb-' + Buffer.from(username).toString('hex');
-}
 
 describe('Rapid requests', function () {
   this.timeout(300_000);
@@ -137,7 +134,7 @@ describe('Rapid requests', function () {
   /* This is a functional test, that the server behaves correctly when overloaded.
    * It must pass on every machine. If no 429s are returned, increase `num` to make the test harder. */
   it('returns "429 Too Many Requests" when a burst of puts or gets continues too long', async function () {
-    const delayMs = 1; const num = 3000;
+    const delayMs = 2; const num = 3000;
     const puts = []; const gets = [];
     for (let i = 0; i < num; ++i) {
       const data = 'ABC' + String(1000 + i);
@@ -226,11 +223,3 @@ describe('Rapid requests', function () {
     expect(response2.statusCode).to.be.oneOf([201, 200]);
   });
 });
-
-function delay (ms) {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve();
-    }, ms);
-  });
-}

--- a/spec/stress/rapid_requests_node14_spec.js
+++ b/spec/stress/rapid_requests_node14_spec.js
@@ -1,0 +1,236 @@
+/* eslint-env mocha, chai, node, browser */
+/* eslint-disable no-unused-expressions */
+
+const os = require('os');
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const expect = chai.expect;
+
+const Armadietto = require('../../lib/armadietto');
+const rmrf = require('rimraf');
+
+chai.use(chaiHttp);
+const port = '5678';
+const host = process.env.SERVER_URL || `http://127.0.0.1:${port}`;
+const storagePath = os.tmpdir() + '/stress-storage';
+const username = process.env.USERNAME || 'stressuser';
+const password = process.env.PASSWORD || 'kladljkfdsoi983';
+const clientId = 'http://example.com';
+
+const req = chai.request(host);
+process.umask(0o077);
+
+function userDbName (username) {
+  return 'userdb-' + Buffer.from(username).toString('hex');
+}
+
+describe('Rapid requests', function () {
+  this.timeout(300_000);
+
+  before(async function () {
+    if (process.env.SERVER_URL) {
+      try {
+        const url = new URL('/oauth', host).href;
+
+        const param = new URLSearchParams({
+          client_id: clientId,
+          redirect_uri: clientId + '/',
+          response_type: 'token',
+          state: '5d0176aa',
+          scope: '/:rw',
+          username,
+          password,
+          allow: 'Allow'
+        });
+        console.info(`    logging in to ${url}: username “${username}” scope “/:rw”`);
+        const resp = await fetch(
+          url,
+          { method: 'POST', body: param }
+        );
+        if (resp.redirected) {
+          const respUrl = new URL(resp.url);
+          const respParam = new URLSearchParams(respUrl.hash.slice(1));
+          this.token = respParam.get('access_token');
+        } else {
+          throw new Error(`${host} didn't redirect; ${resp.status} ${resp.statusText} ${(await resp.text()).slice(0, 60)}`);
+        }
+        console.info(`    using ${username} (CouchDB database ${userDbName(username)})`);
+      } catch (err) {
+        if (err.constructor !== Error) {
+          console.error(`    Is the server running?\n    ${err.name}  ${err.message} -> ${err.cause?.name}  ${err.cause?.message}`);
+        }
+        throw err;
+      }
+    } else {
+      const store = new Armadietto.FileTree({ path: storagePath });
+
+      this.server = new Armadietto({
+        store,
+        http: { port },
+        logging: { log_dir: './stress-log', stdout: [], log_files: ['error'] }
+      });
+      await this.server.boot();
+      await store.createUser({ username, email: 'a@b.co', password });
+      await store.authenticate({ username, password });
+      this.token = await store.authorize(clientId, username, { '/': ['r', 'w'] });
+    }
+  });
+
+  after(async function () {
+    req.close();
+    if (!process.env.SERVER_URL) {
+      await this.server.stop();
+      await new Promise(function (resolve, reject) {
+        rmrf(storagePath, function (err) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+    }
+  });
+
+  /* This serves as a performance floor. As long as it passes in GitHub automation, we're okay.
+   * On slow machines, the expectations might fail */
+  it('serves a burst of many puts and a burst of many gets without error or 429', async function () {
+    const delayMs = 2; const num = 1000;
+    const puts = []; const gets = [];
+    for (let i = 0; i < num; ++i) {
+      const data = 'ABC' + String(1000 + i);
+      const path = `/storage/${username}/many/${i}`;
+      // Chai+Superagent doesn't send right away, unless you call end().
+      puts.push(new Promise((resolve, reject) => {
+        req.put(path).set('Authorization', 'Bearer ' + this.token).type('text/plain').send(Buffer.from(data)).end((err, resp) => {
+          if (err) { reject(err); } else { resolve(resp); }
+        });
+      }));
+      await delay(delayMs);
+    }
+    const putResults = await Promise.all(puts);
+
+    for (let i = 0; i < num; ++i) {
+      // Performance might be slightly different when replacing documents.
+      expect(putResults[i].statusCode).to.be.oneOf([201, 200], `request ${i} failed`);
+    }
+
+    for (let i = 0; i < num; ++i) {
+      const path = `/storage/${username}/many/${i}`;
+      // Chai+Superagent doesn't send right away, unless you call end().
+      gets.push(new Promise((resolve, reject) => {
+        req.get(path).set('Authorization', 'Bearer ' + this.token).end((err, resp) => {
+          if (err) { reject(err); } else { resolve(resp); }
+        });
+      }));
+      await delay(delayMs);
+    }
+    const getResults = await Promise.all(gets);
+
+    for (let i = 0; i < num; ++i) {
+      expect(getResults[i].statusCode).to.equal(200);
+      expect(getResults[i]).to.be.text;
+      expect(getResults[i].text).to.equal('ABC' + String(1000 + i));
+    }
+  });
+
+  /* This is a functional test, that the server behaves correctly when overloaded.
+   * It must pass on every machine. If no 429s are returned, increase `num` to make the test harder. */
+  it('returns "429 Too Many Requests" when a burst of puts or gets continues too long', async function () {
+    const delayMs = 1; const num = 3000;
+    const puts = []; const gets = [];
+    for (let i = 0; i < num; ++i) {
+      const data = 'ABC' + String(1000 + i);
+      const path = `/storage/${username}/more/${i}`;
+      // Chai+Superagent doesn't send right away, unless you call end().
+      puts.push(new Promise((resolve, reject) => {
+        req.put(path).set('Authorization', 'Bearer ' + this.token).type('text/plain').send(Buffer.from(data)).end((err, resp) => {
+          if (err) { reject(err); } else { resolve(resp); }
+        });
+      }));
+      await delay(delayMs);
+    }
+    const putResults = await Promise.all(puts);
+
+    const putStatusCodes = putResults.map(result => result.statusCode);
+    for (let i = 0; i < num; ++i) {
+      expect(putStatusCodes[i]).to.be.oneOf([201, 200, 429]);
+    }
+    expect(putStatusCodes).to.include(201);
+    expect(putStatusCodes).to.include(429);
+
+    // reads are faster, so let's do twice as many
+    for (let j = 0; j < num * 2; ++j) {
+      const i = j % num;
+      const path = `/storage/${username}/more/${i}`;
+      // Chai+Superagent doesn't send right away, unless you call end().
+      gets.push(new Promise((resolve, reject) => {
+        req.get(path).set('Authorization', 'Bearer ' + this.token).end((err, resp) => {
+          if (err) { reject(err); } else { resolve(resp); }
+        });
+      }));
+      await delay(delayMs);
+    }
+    const getResults = await Promise.all(gets);
+
+    for (let j = 0; j < num * 2; ++j) {
+      const i = j % num;
+      if (putResults[i].statusCode === 201) {
+        expect(getResults[j].statusCode).to.be.oneOf([200, 429]);
+        expect(getResults[j]).to.be.text;
+      } else {
+        expect(getResults[j].statusCode).to.be.oneOf([200, 404, 429]);
+      }
+    }
+
+    const getStatusCodes = getResults.map(result => result.statusCode);
+    expect(getStatusCodes).to.include(200);
+    expect(getStatusCodes).to.include(404);
+    expect(getStatusCodes).to.include(429);
+  });
+
+  /* This serves as a performance floor. As long as it passes in GitHub automation, we're okay.
+   * If the expectations fail, the storage on that system is probably too slow for Armadietto. */
+  it('handles rapid large puts without error', async function () {
+    const article1 = 'All human beings are born free and equal in dignity and rights. They are endowed with reason and conscience and should act towards one another in a spirit of brotherhood.';
+
+    const article2 = 'Everyone is entitled to all the rights and freedoms set forth in this Declaration, without distinction of any kind, such as race, colour, sex, language, religion, political or other opinion, national or social origin, property, birth or other status. Furthermore, no distinction shall be made on the basis of the political, jurisdictional or international status of the country or territory to which a person belongs, whether it be independent, trust, non-self-governing or under any other limitation of sovereignty.';
+
+    const path1 = `/storage/${username}/big/1`;
+    const request1 = req.put(path1).set('Authorization', 'Bearer ' + this.token).type('text/plain');
+    for (let i = 0; i < 200_000_000 / article1.length; ++i) {
+      request1.send(article1);
+    }
+
+    const path2 = `/storage/${username}/big/2`;
+    const request2 = req.put(path2).set('Authorization', 'Bearer ' + this.token).type('text/plain');
+    for (let i = 0; i < 200_000_000 / article2.length; ++i) {
+      request2.send(article2);
+    }
+
+    const promise1 = new Promise((resolve, reject) => {
+      request1.end((err, resp) => {
+        if (err) { reject(err); } else { resolve(resp); }
+      });
+    });
+    const promise2 = new Promise((resolve, reject) => {
+      request2.end((err, resp) => {
+        if (err) { reject(err); } else { resolve(resp); }
+      });
+    });
+    const response1 = await promise1;
+    // Performance might be slightly different when replacing documents.
+    expect(response1.statusCode).to.be.oneOf([201, 200]);
+
+    const response2 = await promise2;
+    expect(response2.statusCode).to.be.oneOf([201, 200]);
+  });
+});
+
+function delay (ms) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}

--- a/spec/stress/rapid_requests_spec.js
+++ b/spec/stress/rapid_requests_spec.js
@@ -1,0 +1,188 @@
+/* eslint-env mocha, chai, node */
+/* eslint-disable no-unused-expressions */
+
+const os = require('os');
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const expect = chai.expect;
+
+const Armadietto = require('../../lib/armadietto');
+const rmrf = require('rimraf');
+
+chai.use(chaiHttp);
+const port = '5678';
+const host = `http://localhost:${port}`;
+const storagePath = os.tmpdir() + '/stress-storage';
+const username = 'stressuser';
+const password = 'kladljkfdsoi983';
+const clientId = 'http://localhost:3000';
+
+const req = chai.request(host);
+process.umask(0o077);
+
+describe('Rapid requests', function () {
+  this.timeout(300_000);
+
+  before(async function () {
+    const store = new Armadietto.FileTree({ path: storagePath });
+
+    this.server = new Armadietto({
+      store,
+      http: { port },
+      logging: { log_dir: './stress-log', stdout: [], log_files: ['error'] }
+    });
+    await this.server.boot();
+    await store.createUser({ username, email: 'a@b.co', password });
+    await store.authenticate({ username, password });
+    this.token = await store.authorize(clientId, username, { '/': ['r', 'w'] });
+  });
+
+  after(async function () {
+    req.close();
+    await this.server.stop();
+    await new Promise(function (resolve, reject) {
+      rmrf(storagePath, function (err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+
+  it('serves a burst of many puts or gets without error', async function () {
+    const delayMs = 1; const num = 1000;
+    const puts = []; const gets = [];
+    for (let i = 0; i < num; ++i) {
+      const data = 'ABC' + String(1000 + i);
+      const path = `/storage/${username}/many/${i}`;
+      // Chai+Superagent doesn't send right away, unless you call end().
+      puts.push(new Promise((resolve, reject) => {
+        req.put(path).set('Authorization', 'Bearer ' + this.token).type('text/plain').send(Buffer.from(data)).end((err, resp) => {
+          if (err) { reject(err); } else { resolve(resp); }
+        });
+      }));
+      await delay(delayMs);
+    }
+    const putResults = await Promise.all(puts);
+
+    for (let i = 0; i < num; ++i) {
+      expect(putResults[i].statusCode).to.equal(201, `request ${i} failed`);
+    }
+
+    for (let i = 0; i < num; ++i) {
+      const path = `/storage/${username}/many/${i}`;
+      // Chai+Superagent doesn't send right away, unless you call end().
+      gets.push(new Promise((resolve, reject) => {
+        req.get(path).set('Authorization', 'Bearer ' + this.token).end((err, resp) => {
+          if (err) { reject(err); } else { resolve(resp); }
+        });
+      }));
+      await delay(delayMs);
+    }
+    const getResults = await Promise.all(gets);
+
+    for (let i = 0; i < num; ++i) {
+      expect(getResults[i].statusCode).to.equal(200);
+      expect(getResults[i]).to.be.text;
+      expect(getResults[i].text).to.equal('ABC' + String(1000 + i));
+    }
+  });
+
+  it('returns "429 Too Many Requests" when a burst of puts or gets continues too long', async function () {
+    const delayMs = 1; const num = 3000;
+    const puts = []; const gets = [];
+    for (let i = 0; i < num; ++i) {
+      const data = 'ABC' + String(1000 + i);
+      const path = `/storage/${username}/more/${i}`;
+      // Chai+Superagent doesn't send right away, unless you call end().
+      puts.push(new Promise((resolve, reject) => {
+        req.put(path).set('Authorization', 'Bearer ' + this.token).type('text/plain').send(Buffer.from(data)).end((err, resp) => {
+          if (err) { reject(err); } else { resolve(resp); }
+        });
+      }));
+      await delay(delayMs);
+    }
+    const putResults = await Promise.all(puts);
+
+    const putStatusCodes = putResults.map(result => result.statusCode);
+    for (let i = 0; i < num; ++i) {
+      expect(putStatusCodes[i]).to.be.oneOf([201, 429]);
+    }
+    expect(putStatusCodes).to.include(201);
+    expect(putStatusCodes).to.include(429);
+
+    // reads are faster, so let's do twice as many
+    for (let j = 0; j < num * 2; ++j) {
+      const i = j % num;
+      const path = `/storage/${username}/more/${i}`;
+      // Chai+Superagent doesn't send right away, unless you call end().
+      gets.push(new Promise((resolve, reject) => {
+        req.get(path).set('Authorization', 'Bearer ' + this.token).end((err, resp) => {
+          if (err) { reject(err); } else { resolve(resp); }
+        });
+      }));
+      await delay(delayMs);
+    }
+    const getResults = await Promise.all(gets);
+
+    for (let j = 0; j < num * 2; ++j) {
+      const i = j % num;
+      if (putResults[i].statusCode === 201) {
+        expect(getResults[j].statusCode).to.be.oneOf([200, 429]);
+        expect(getResults[j]).to.be.text;
+      } else {
+        expect(getResults[j].statusCode).to.be.oneOf([404, 429]);
+      }
+    }
+
+    const getStatusCodes = getResults.map(result => result.statusCode);
+    expect(getStatusCodes).to.include(200);
+    expect(getStatusCodes).to.include(404);
+    expect(getStatusCodes).to.include(429);
+  });
+
+  // This only needs to be tested on systems with slow storage.
+  it('handles rapid large puts without error', async function () {
+    const article1 = 'All human beings are born free and equal in dignity and rights. They are endowed with reason and conscience and should act towards one another in a spirit of brotherhood.';
+
+    const article2 = 'Everyone is entitled to all the rights and freedoms set forth in this Declaration, without distinction of any kind, such as race, colour, sex, language, religion, political or other opinion, national or social origin, property, birth or other status. Furthermore, no distinction shall be made on the basis of the political, jurisdictional or international status of the country or territory to which a person belongs, whether it be independent, trust, non-self-governing or under any other limitation of sovereignty.';
+
+    const path1 = `/storage/${username}/big/1`;
+    const request1 = req.put(path1).set('Authorization', 'Bearer ' + this.token).type('text/plain');
+    for (let i = 0; i < 500_000_000 / article1.length; ++i) {
+      request1.send(article1);
+    }
+
+    const path2 = `/storage/${username}/big/2`;
+    const request2 = req.put(path2).set('Authorization', 'Bearer ' + this.token).type('text/plain');
+    for (let i = 0; i < 500_000_000 / article2.length; ++i) {
+      request2.send(article2);
+    }
+
+    const promise1 = new Promise((resolve, reject) => {
+      request1.end((err, resp) => {
+        if (err) { reject(err); } else { resolve(resp); }
+      });
+    });
+    const promise2 = new Promise((resolve, reject) => {
+      request2.end((err, resp) => {
+        if (err) { reject(err); } else { resolve(resp); }
+      });
+    });
+    const response1 = await promise1;
+    expect(response1.statusCode).to.equal(201);
+
+    const response2 = await promise2;
+    expect(response2.statusCode).to.equal(201);
+  });
+});
+
+function delay (ms) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}

--- a/spec/stress/rapid_requests_spec.js
+++ b/spec/stress/rapid_requests_spec.js
@@ -51,8 +51,10 @@ describe('Rapid requests', function () {
     });
   });
 
+  /* This serves as a performance floor. As long as it passes in GitHub automation, we're okay.
+   * On slow machines, the expectations might fail */
   it('serves a burst of many puts or gets without error', async function () {
-    const delayMs = 1; const num = 1000;
+    const delayMs = 2; const num = 1000;
     const puts = []; const gets = [];
     for (let i = 0; i < num; ++i) {
       const data = 'ABC' + String(1000 + i);
@@ -90,6 +92,8 @@ describe('Rapid requests', function () {
     }
   });
 
+  /* This is a functional test, that the server behaves correctly when overloaded.
+   * It must pass on every machine. If no 429s are returned, increase `num` to make the test harder. */
   it('returns "429 Too Many Requests" when a burst of puts or gets continues too long', async function () {
     const delayMs = 1; const num = 3000;
     const puts = []; const gets = [];
@@ -143,7 +147,8 @@ describe('Rapid requests', function () {
     expect(getStatusCodes).to.include(429);
   });
 
-  // This only needs to be tested on systems with slow storage.
+  /* This serves as a performance floor. As long as it passes in GitHub automation, we're okay.
+   * If the expectations fail, the storage on that system is probably too slow for Armadietto. */
   it('handles rapid large puts without error', async function () {
     const article1 = 'All human beings are born free and equal in dignity and rights. They are endowed with reason and conscience and should act towards one another in a spirit of brotherhood.';
 
@@ -151,13 +156,13 @@ describe('Rapid requests', function () {
 
     const path1 = `/storage/${username}/big/1`;
     const request1 = req.put(path1).set('Authorization', 'Bearer ' + this.token).type('text/plain');
-    for (let i = 0; i < 500_000_000 / article1.length; ++i) {
+    for (let i = 0; i < 200_000_000 / article1.length; ++i) {
       request1.send(article1);
     }
 
     const path2 = `/storage/${username}/big/2`;
     const request2 = req.put(path2).set('Authorization', 'Bearer ' + this.token).type('text/plain');
-    for (let i = 0; i < 500_000_000 / article2.length; ++i) {
+    for (let i = 0; i < 200_000_000 / article2.length; ++i) {
       request2.send(article2);
     }
 

--- a/spec/stress_runner.js
+++ b/spec/stress_runner.js
@@ -1,2 +1,6 @@
-
+/* Occasionally, expectations in these tests may fail, because the system was heavily loaded with other jobs.
+   That's okay (except for tests marked as functional).
+   If an expectation persistently fails, investigate why Armadietto is performing worse than before.
+   If the tests fail to complete, fix them!
+ */
 require('./stress/rapid_requests_spec');

--- a/spec/stress_runner.js
+++ b/spec/stress_runner.js
@@ -1,0 +1,2 @@
+
+require('./stress/rapid_requests_spec');

--- a/spec/stress_runner_auto.js
+++ b/spec/stress_runner_auto.js
@@ -1,0 +1,6 @@
+/* Occasionally, expectations in these tests may fail, because the system was heavily loaded with other jobs.
+   That's okay (except for tests marked as functional).
+   If an expectation persistently fails, investigate why Armadietto is performing worse than before.
+   If the tests fail to complete, fix them!
+ */
+require('./stress/rapid_requests_node14_spec');

--- a/spec/util/test_util.js
+++ b/spec/util/test_util.js
@@ -1,0 +1,60 @@
+/* eslint-env node, browser */
+
+const CHUNK_SIZE = 1024;
+const encoder = new TextEncoder();
+
+function streamFactory (targetSize, seed = 1) {
+  let count = 0;
+
+  const stream = new ReadableStream({
+    type: 'bytes',
+    autoAllocateChunkSize: CHUNK_SIZE,
+    pull (controller) {
+      if (controller.byobRequest) {
+        const numRemaining = targetSize - count;
+        const view = controller.byobRequest.view; // Uint8Array(256)
+        const numToWrite = Math.min(view.length, numRemaining);
+
+        encoder.encodeInto(someChars(numToWrite, seed), view);
+        count += numToWrite;
+        controller.byobRequest.respond(numToWrite);
+
+        if (count >= targetSize) {
+          controller.close();
+        }
+      } else {
+        console.log('byobRequest was null');
+        const chunkSize = Math.max(controller.desiredSize, CHUNK_SIZE);
+        if (targetSize - count > chunkSize) {
+          const str = someChars(chunkSize, seed);
+          count += str.length;
+          controller.enqueue(str);
+        } else if (targetSize > count) {
+          const str = someChars(targetSize - count, seed);
+          count += str.length;
+          controller.enqueue(str);
+        } else {
+          controller.close();
+        }
+      }
+    }
+  });
+  return stream;
+}
+
+const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!@#$%^&*()';
+
+function someChars (num, seed) {
+  let string = charset.charAt(seed % charset.length);
+
+  while (string.length < num) {
+    string += ' ' + seed;
+  }
+
+  string = string.slice(0, num);
+  string[num - 1] = ' ';
+
+  return string;
+}
+
+module.exports = { streamFactory };

--- a/spec/util/test_util_node14.js
+++ b/spec/util/test_util_node14.js
@@ -1,0 +1,15 @@
+/* eslint-env node, browser */
+
+function userDbName (username) {
+  return 'userdb-' + Buffer.from(username).toString('hex');
+}
+
+function delay (ms) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}
+
+module.exports = { userDbName, delay };


### PR DESCRIPTION
The scenario and its importance are laid out in detail at https://community.remotestorage.io/t/retry-of-failed-writes/766
**Implications for Armadietto:**
* Failed puts are not retried (thus losing user data), so a server should work hard to make them succeed.
* The issue is most acute when importing or copying documents from another RS server. I have observed multiple put errors, when importing hundreds of documents at 10 requests/second.
* It's useful to test at a very high rate, so test results are less variable. For requests arriving 1/ms, the current burst length that can be handled (on my dev machine) is 3. Increasing the file lock wait time increases the burst length to thousands. On my dev machine, at 1 request/3 ms, burst length appeared to be unlimited, so reasonable request rates should be sustainable.
* If a file lock is not available during the wait time, we should send "429 Too Many Requests", so it's clear this is a client issue, not a server issue.
