### PR TITLE
Reduces # of OPTIONS requests by sending Access-Control-Max-Age header

### DIFF
--- a/lib/controllers/storage.js
+++ b/lib/controllers/storage.js
@@ -16,6 +16,7 @@ class Storage extends Controller {
 
     this._headers = {
       'Access-Control-Allow-Origin': this.request.headers.origin || '*',
+      'Vary': 'Origin',
       'Access-Control-Expose-Headers': 'Content-Length, Content-Type, ETag',
       'Cache-Control': 'no-cache'
     };
@@ -24,9 +25,10 @@ class Storage extends Controller {
   options () {
     this._headers['Access-Control-Allow-Methods'] = 'OPTIONS, GET, HEAD, PUT, DELETE';
     this._headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Length, Content-Type, If-Match, If-None-Match, Origin, X-Requested-With';
-    this.response.writeHead(200, this._headers);
+    this._headers['Access-Control-Max-Age'] = 7200;
+    this.response.writeHead(204, this._headers);
     this.response.end();
-    logRequest(this.request, this._username, 200, 0, '', 'debug');
+    logRequest(this.request, this._username, 204, 0, '', 'debug');
   }
 
   async get (head = false) {

--- a/lib/controllers/storage.js
+++ b/lib/controllers/storage.js
@@ -16,7 +16,7 @@ class Storage extends Controller {
 
     this._headers = {
       'Access-Control-Allow-Origin': this.request.headers.origin || '*',
-      'Vary': 'Origin',
+      Vary: 'Origin',
       'Access-Control-Expose-Headers': 'Content-Length, Content-Type, ETag',
       'Cache-Control': 'no-cache'
     };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -107,7 +107,20 @@ function logRequest (req, username, status, numBytesWritten, logNote, logLevel) 
 
   const clientAddress = req.headers['x-forwarded-for'] || req.socket.address().address;
 
-  let line = `${clientAddress} ${username} ${req.method} ${req.url} ${status} ${numBytesWritten}`;
+  let appHost;
+  if ('null' === req.headers.origin) {
+    appHost = 'null';
+  } else if (req.headers.origin) {
+    const originUrl = new URL(req.headers.origin);
+    appHost = originUrl.host || originUrl.origin;
+  } else if (req.headers.referer) {
+    const refererUrl = new URL(req.headers.referer);
+    appHost = refererUrl.host || refererUrl.origin;
+  } else {
+    appHost = '-';
+  }
+
+  let line = `${clientAddress} ${appHost} ${username} ${req.method} ${req.url} ${status} ${numBytesWritten}`;
   if (logNote) {
     if (logNote instanceof Error) {
       logNote = logNote.message || logNote.code || logNote.name || logNote.toString();

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -108,7 +108,7 @@ function logRequest (req, username, status, numBytesWritten, logNote, logLevel) 
   const clientAddress = req.headers['x-forwarded-for'] || req.socket.address().address;
 
   let appHost;
-  if ('null' === req.headers.origin) {
+  if (req.headers.origin === 'null') {
     appHost = 'null';
   } else if (req.headers.origin) {
     const originUrl = new URL(req.headers.origin);

--- a/spec/armadietto/storage_spec.js
+++ b/spec/armadietto/storage_spec.js
@@ -78,13 +78,16 @@ describe('Storage', () => {
 
   describe('OPTIONS', () => {
     it('returns access control headers', async () => {
-      const res = await req.options('/storage/zebcoe/locog/seats').buffer(true);
-      expect(res).to.have.status(200);
-      expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+      const res = await req.options('/storage/zebcoe/locog/seats').set('Origin', 'https://example.com').buffer(true);
+      expect(res.statusCode).to.be.oneOf([200, 204]);
+      expect(res).to.have.header('Access-Control-Allow-Origin', 'https://example.com');
+      expect(res).to.have.header('Vary', 'Origin');
       expect(res).to.have.header('Access-Control-Allow-Headers', 'Authorization, Content-Length, Content-Type, If-Match, If-None-Match, Origin, X-Requested-With');
       expect(res).to.have.header('Access-Control-Allow-Methods', 'OPTIONS, GET, HEAD, PUT, DELETE');
       expect(res).to.have.header('Access-Control-Expose-Headers', 'Content-Length, Content-Type, ETag');
       expect(res).to.have.header('Cache-Control', 'no-cache');
+      expect(res).to.have.header('Access-Control-Max-Age');
+      expect(parseInt(res.header['access-control-max-age'])).to.be.greaterThan(10);
       expect(res.text).to.be.equal('');
     });
   });


### PR DESCRIPTION
CORS prefilght requests are cached for 5 seconds by default - so polling at 10 second intervals requires a preflight OPTIONS request for **every** GET.  Sending Access-Control-Max-Age header tells the browser 'you can call this endpoint for the next two hours without sending another preflight request'.  Thus, the number of requests while the app is idling is **halved**.

Also update logging to display the requesting webapp, from the Origin header sent in CORS requests.