### PR TITLE
Adds node v18 as supported platform, and removes obsolete node v12

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Run tests
         run: npm test
       - name: Run linter

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # Support LTS versions based on https://nodejs.org/en/about/releases/
-        node-version: ['12', '14', '16']
+        node-version: ['14', '16', '18']
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -13,9 +13,9 @@ jobs:
         # Support LTS versions based on https://nodejs.org/en/about/releases/
         node-version: ['14', '16', '18']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "version": "0.2.0",
   "engines": {
-    "node": ">=12.x"
+    "node": ">=14.0"
   },
   "bin": {
     "armadietto": "./bin/armadietto.js"

--- a/spec/armadietto/oauth_spec.js
+++ b/spec/armadietto/oauth_spec.js
@@ -9,7 +9,7 @@ const Armadietto = require('../../lib/armadietto');
 chai.use(chaiHttp);
 chai.use(spies);
 
-const req = chai.request('http://localhost:4567');
+const req = chai.request('http://127.0.0.1:4567');
 const get = async (path, params) => {
   const ret = await req.get(path)
     .redirects(0)

--- a/spec/armadietto/signup_spec.js
+++ b/spec/armadietto/signup_spec.js
@@ -14,7 +14,7 @@ const store = {
   }
 };
 const port = '4569';
-const host = `http://localhost:${port}`;
+const host = `http://127.0.0.1:${port}`;
 const req = chai.request(host);
 
 const get = async (path) => {
@@ -101,7 +101,7 @@ describe('Signup w/ base path & signup', () => {
   it('redirects to the home page', async () => {
     const res = await get('');
     expect(res).to.redirect;
-    expect(res).to.redirectTo('http://localhost:4569/basic');
+    expect(res).to.redirectTo('http://127.0.0.1:4569/basic');
   });
 
   it('returns a home page w/ signup link', async () => {

--- a/spec/armadietto/storage_spec.js
+++ b/spec/armadietto/storage_spec.js
@@ -11,7 +11,7 @@ chai.use(chaiHttp);
 chai.use(chaiAsPromised);
 chai.use(spies);
 
-// const req = chai.request('http://localhost:4568');
+// const req = chai.request('http://127.0.0.1:4568');
 const store = {
   get (username, path) {
     return { item: null, versionMatch: true };
@@ -53,7 +53,7 @@ describe('Storage', () => {
     })();
   });
 
-  const req = chai.request('http://localhost:4567');
+  const req = chai.request('http://127.0.0.1:4567');
   subject('req', () => req.get(get.path));
 
   describe('when the client uses path traversal in the path', () => {
@@ -214,7 +214,7 @@ describe('Storage', () => {
         expect(res).to.have.status(401);
         expect(res).to.have.header('Access-Control-Allow-Origin', '*');
         expect(res).to.have.header('Cache-Control', 'no-cache');
-        expect(res).to.have.header('WWW-Authenticate', 'Bearer realm="localhost:4567" error="invalid_token"');
+        expect(res).to.have.header('WWW-Authenticate', 'Bearer realm="127.0.0.1:4567" error="invalid_token"');
       });
     });
 

--- a/spec/armadietto/web_finger_spec.js
+++ b/spec/armadietto/web_finger_spec.js
@@ -10,7 +10,7 @@ chai.use(chaiHttp);
 chai.use(spies);
 const store = {};
 const port = '4569';
-const host = `http://localhost:${port}`;
+const host = `http://127.0.0.1:${port}`;
 const req = chai.request(host);
 
 const get = async (path) => {
@@ -146,12 +146,12 @@ describe('WebFinger', () => {
     expect(trim(res.text)).to.be.equal(trim(`
       <?xml version="1.0" encoding="UTF-8"?>
       <XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
-        <Link href="http://localhost:${port}/storage/zebcoe" rel="remotestorage" type="draft-dejong-remotestorage-01">
+        <Link href="http://127.0.0.1:${port}/storage/zebcoe" rel="remotestorage" type="draft-dejong-remotestorage-01">
           <Property type="auth-method">http://tools.ietf.org/html/rfc6749#section-4.2</Property>
-          <Property type="auth-endpoint">http://localhost:${port}/oauth/zebcoe</Property>
+          <Property type="auth-endpoint">http://127.0.0.1:${port}/oauth/zebcoe</Property>
           <Property type="http://remotestorage.io/spec/version">draft-dejong-remotestorage-01</Property>
           <Property type="http://tools.ietf.org/html/rfc6750#section-2.3">true</Property>
-          <Property type="http://tools.ietf.org/html/rfc6749#section-4.2">http://localhost:${port}/oauth/zebcoe</Property>
+          <Property type="http://tools.ietf.org/html/rfc6749#section-4.2">http://127.0.0.1:${port}/oauth/zebcoe</Property>
         </Link>
       </XRD>`));
   });


### PR DESCRIPTION
As of 2022-04-19, node v18 is current. As of 2022-04-30, node v12 is EOL.