### PR TITLE
Fix PUTing documents with If-None-Match when non-existent

### DIFF
--- a/lib/controllers/storage.js
+++ b/lib/controllers/storage.js
@@ -33,10 +33,12 @@ class Storage extends Controller {
 
   async get (head = false) {
     const version = this.getVersion();
+    const matchVersion = !!this.request.headers['if-match'];
+
     if (await this.checkToken('r')) {
       let numBytesWritten = 0;
       try {
-        var { item, versionMatch } = await this.server._store.get(this._username, this._path, version, head);
+        var { item, versionMatch } = await this.server._store.get(this._username, this._path, version, matchVersion, head);
       } catch (e) {
         getLogger().error(`Your storage backend does not behave correctly => ${e.message}`);
         this.response.writeHead(500, this._headers);
@@ -59,7 +61,7 @@ class Storage extends Controller {
       }
 
       this.setVersion(item && item.ETag);
-      if (versionMatch) {
+      if (!matchVersion && versionMatch) {
         delete this._headers['Content-Type'];
         this.response.writeHead(304, this._headers);
         this.response.end();
@@ -86,10 +88,14 @@ class Storage extends Controller {
       return false;
     }
     const version = this.getVersion();
+    const matchVersion = !!this.request.headers['if-match'];
+
     let status, error, created, modified, conflict, isDir;
     if (await this.checkToken('w')) {
       try {
-        ({ created, modified, conflict, isDir } = await this.server._store.put(this._username, this._path, type, value, version));
+        ({ created, modified, conflict, isDir } = await this.server._store.put(
+          this._username, this._path, type, value, version, matchVersion
+        ));
         status = conflict
           ? 412
           : isDir

--- a/lib/stores/file_tree.js
+++ b/lib/stores/file_tree.js
@@ -198,7 +198,7 @@ class FileTree {
     }
   }
 
-  async put (username, pathname, type, value, version) {
+  async put (username, pathname, type, value, version, matchVersion) {
     const datapath = this.dataPath(username, pathname);
     const metapath = this._metaPath(username, pathname);
     const basename = decodeURI(path.basename(pathname));
@@ -206,7 +206,7 @@ class FileTree {
     const metadata = await this.readMeta(username, pathname);
     let created = false;
 
-    if (version) {
+    if (version && matchVersion) {
       if (version === '*'
         // check document existence when version '*' specified
         ? metadata.items && metadata.items[basename]
@@ -214,6 +214,12 @@ class FileTree {
         : !metadata.items || !metadata.items[basename] ||
           version.replace(/"/g, '') !== metadata.items[basename].ETag
       ) {
+        await this._unlock(username);
+        return { conflict: true, created };
+      }
+    } else if (version && !matchVersion) {
+      if (metadata.items && metadata.items[basename] &&
+         version.replace(/"/g, '') === metadata.items[basename].ETag) {
         await this._unlock(username);
         return { conflict: true, created };
       }


### PR DESCRIPTION
I found a pretty glaring bug when I tried to restore documents via [rs-backup](https://github.com/raucao/rs-backup) for development on my local machine:

The code currently does not discern between `If-Match` and `If-None-Match` in both the GET and PUT functions. It will just grab whichever header is set as the "version" and treat both headers the same way. When restoring a backup, and thus sending an ETAG in `If-None-Match` for a non-existent document (i.e. "create or update this document if there isn't one that matches this ETAG"), Armadietto will thus respond with a 412 conflict status.

This changeset fixes the bug, but I have not looked at the tests for it. I would appreciate if a more regular contributor could add the respective tests, since I currently don't have more time to spend on this. Thank you.