### PR TITLE
In approved app listing, removes favicons, replaces clientId with appName

### DIFF
--- a/lib/controllers/base.js
+++ b/lib/controllers/base.js
@@ -123,7 +123,7 @@ class Controller {
     const headers = {
       'Content-Length': html.length,
       'Content-Type': 'text/html; charset=utf8',
-      'Content-Security-Policy': "sandbox allow-scripts allow-forms allow-same-origin; default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; object-src 'none'; child-src 'none'; connect-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+      'Content-Security-Policy': "sandbox allow-scripts allow-forms allow-popups allow-same-origin; default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; object-src 'none'; child-src 'none'; connect-src 'none'; base-uri 'self'; frame-ancestors 'none';",
       'X-Content-Type-Options': 'nosniff',
       'Referrer-Policy': 'no-referrer'
     };

--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -66,14 +66,15 @@ class Users extends Controller {
         params: { username: this.params.username },
         host: this.getHost(),
         sessions: authData.sessions
-          ? Object.keys(authData.sessions).map(k => {
+          ? Object.values(authData.sessions).map(session => {
             return {
-              clientId: authData.sessions[k].clientId,
-              permissions: Object.keys(authData.sessions[k].permissions).map(folder => {
+              clientId: session.clientId,
+              appName: /https?:\/\/([a-zA-Z\d-]+)[.:$]/.exec(session.clientId)?.[1] || '',
+              permissions: Object.entries(session.permissions).map(([folder, perms]) => {
                 return {
                   folder,
-                  permissions: Object.keys(authData.sessions[k].permissions[folder]).filter(perm => {
-                    return authData.sessions[k].permissions[folder][perm];
+                  permissions: Object.keys(perms).filter(perm => {
+                    return perms[perm];
                   }).map(v => expandedPermissions[v])
                 };
               })

--- a/lib/views/account.html
+++ b/lib/views/account.html
@@ -15,8 +15,7 @@
 		<% sessions.forEach(function(session) { %>
 			<tr>
 				<td>
-					<img src="<%= session.clientId %>/favicon.ico" alt="Favicon for <%= session.clientId %>" class="favicon">
-					<a href="<%= session.clientId %>" target="_blank"><%= session.clientId %></a>
+					<a href="<%= session.clientId %>" target="_blank"><%= session.appName %></a>
 				</td>
 				<td>
 					<% session.permissions.forEach(folder => { %>


### PR DESCRIPTION
We wouldn't get favicons that weren't in the root directory, and we'd have allow loading images from **any** site, which is a big reduction in security for minimal gain.

Displays the subdomain instead of the whole URL for clarity, and adds permission for `target="_blank"`