### PR TITLE
ETags in folder listings match what remotestorage.js expects

### DIFF
--- a/lib/routes/S3_store_router.js
+++ b/lib/routes/S3_store_router.js
@@ -208,7 +208,7 @@ module.exports = function ({ endPoint = 'play.min.io', accessKey = 'Q3AM3UQ867SP
         const putETag = await putBlob(bucketName, s3Path, contentType, contentLength, req);
 
         const documentMetadata = {
-          ETag: putETag,
+          ETag: stripQuotes(putETag),
           'Content-Type': contentType,
           ...(contentLength >= 0 ? { 'Content-Length': contentLength } : null),
           'Last-Modified': new Date().toUTCString()
@@ -700,8 +700,8 @@ module.exports = function ({ endPoint = 'play.min.io', accessKey = 'Q3AM3UQ867SP
           } else { // item is folder
             const itemName = basename(itemPath) + '/';
             if (metadata) { // folder item exists
-              if (parent.items[itemName]?.ETag !== metadata) {
-                parent.items[itemName] = { ETag: metadata };
+              if (parent.items[itemName]?.ETag !== stripQuotes(metadata)) {
+                parent.items[itemName] = { ETag: stripQuotes(metadata) };
                 didChangeParent = true;
               }
             } else { // folder item does not exist
@@ -844,4 +844,8 @@ class S3RequestLogger extends NodeHttpHandler {
       return response;
     });
   }
+}
+
+function stripQuotes (ETag) {
+  return ETag.replace(/^"|^W\/"|"$/g, '');
 }


### PR DESCRIPTION
remotestorage.js expects folder listings to contain ETags without the quotation marks. :-(
