### PR TITLE
Updates documentation on development of modular server

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,8 @@
 ## Development
 
 * Run `npm test` to run the automated tests for both monolithic and modular servers (except the tests for S3 store router).
-* Set the S3 environment variables and run Mocha with `./node_modules/mocha/bin/mocha.js -u bdd-lazy-var/getter spec/armadietto/storage_spec.js` to test the S3 store router using your configured S3 server. (If the S3 environment variables aren't set, the S3 router uses the shared public account on play.min.io.) If any tests fail, add a note to [the S3 notes](notes/S3-store-router.md)
+* If you don't have an S3-compatible server configured, run `npm test-s3-wo-configured-server`
+* Set the S3 environment variables and run Mocha with `./node_modules/mocha/bin/mocha.js -u bdd-lazy-var/getter spec/armadietto/storage_spec.js` to test the S3 store router using your configured S3 server. (If the S3 environment variables aren't set, the S3 router uses the shared public account on play.min.io.) If any tests fail on one S3 implementation but not others, add a note to [the S3 notes](notes/S3-store-router.md)
 * Run `npm run modular` to start a modular server on your local machine, and have it automatically restart when you update a source code file in `/lib`.
 * Run `npm run dev` to start a monolithic server on your local machine, and have it automatically restart when you update a source code file in `/lib`.
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ See [the Docker README](./docker/README.md)
 2. If you will be using Apache as a reverse proxy, ensure it is [version 2.4.49 or later](https://community.remotestorage.io/t/avoid-apache-as-a-basis-for-your-server/139).
 3. Run `npm -g i armadietto`
 
-
 ## Usage
 
-See the `notes` directory for configuring a reverse proxy and other recipes.
+See the `notes` directory for [configuring a reverse proxy](notes/reverse-proxy-configuration.md) and other recipes.
 
 ### Modular (new) Server
 
@@ -46,6 +45,13 @@ See [the modular-server-specific documentation](./notes/modular-server.md) for u
 * Implements older spec: draft-dejong-remotestorage-01
 
 See [the monolithic-server-specific documentation](./notes/monolithic-server.md) for usage.
+
+### In Production
+
+In production, configure systemd (or the equivalent in your OS) to run armadietto.  See [the systemd docs](../contrib/systemd/README.md).
+Don't use shell scripts nor `nodemon` to keep Armadietto running.
+They respond much slower, are more fragile to unexpected situations, are harder to maintain, and can't be administered like other services.
+
 
 ## Storage security
 
@@ -128,7 +134,7 @@ The `force: true` line in the `https` section means the app will:
 * Refuse to process POST authentication requests over insecure connections
 * Block insecure storage requests and revoke the client's access
 
-Armadietto considers a request to be secure if:
+Armadietto considers a request to be secure if one of the following is set:
 
 * armadietto itself acts as an SSL terminator and the connection to it is encrypted
 * The `X-Forwarded-SSL` header has the value `on`
@@ -148,7 +154,7 @@ Set the environment `DEBUG` to enable logging.  For example `DEBUG=true armadiet
 
 ## Development
 
-See `DEVELOPMENT.md`
+See [`DEVELOPMENT.md`](./DEVELOPMENT.md)
 
 ## License
 

--- a/bin/www
+++ b/bin/www
@@ -53,11 +53,11 @@ if (!hostIdentity) {
 const userNameSuffix = conf.user_name_suffix ?? '-' + hostIdentity;
 
 if (conf.http?.port) {
-  start( Object.assign({}, conf.http, process.env.PORT && {port: process.env.PORT})).catch(getLogger.error);
+  start( Object.assign({}, conf.http, process.env.PORT && {port: process.env.PORT})).catch(getLogger().error);
 }
 
 if (conf.https?.enable) {
-  start(conf.https).catch(getLogger.error);
+  start(conf.https).catch(getLogger().error);
 }
 
 

--- a/lib/views/login/request-invite-success.html
+++ b/lib/views/login/request-invite-success.html
@@ -4,7 +4,7 @@
 <h2>Invitation Requested</h2>
 </header>
 
-<p>Check that clicking this link starts a message to you:</p>
+<p class="centeredText">Check that clicking this link starts a message to you:</p>
 
 <p class="centeredText"><a href="<%= params.contactURL %>"><%= params.contactURL %></a></p>
 

--- a/notes/S3-store-router.md
+++ b/notes/S3-store-router.md
@@ -15,7 +15,6 @@ Tested services include:
 ### Garage
 
 * doesn't implement versioning (which would be nice for recovery)
-* doesn't implement If-Match for GET, which is not yet used but will be required to support Range requests
 
 ### min.io (both self-hosted and cloud)
 

--- a/notes/modular-server.md
+++ b/notes/modular-server.md
@@ -6,11 +6,33 @@ There's an NPM module for almost anything worth doing in a Node.js server (albei
 
 ## Installation
 
+### S3-compatible storage
+
 In addition to installing Armadietto, you **MUST** have a server  with an S3-compatible interface.
 If your hosting provider doesn't offer S3-compatible storage as a service, you can self-host using any of several open-source servers, on the same machine as Armadietto if you like.
 
 See [S3-compatible Streaming Store](S3-store-router.md) for compatability of various implementations.
 [Garage](https://garagehq.deuxfleurs.fr/) is used while developing Armadietto.
+
+For testing, you can not set the [S3 environment variables](S3-store-router.md#configuration), in which case the S3 router will use the public account on `play.min.io`, where the documents & folders can be **read, altered and deleted** by anyone in the world!
+
+### Secure origin
+
+The modular server uses Passkeys and the Web Authentication API.
+This requires a secure origin — it must be served over HTTPS.
+If you don't have another source of TLS certificates for your production machine, [Let's Encript](https://letsencrypt.org/docs/) is a good choice.
+
+
+To develop or run the modular server locally, add a new entry for the local machine under a new name, to `/etc/hosts` .  For example
+```
+127.0.0.1 foo.example.org
+```
+and then use [`mkcert`](https://github.com/FiloSottile/mkcert) to generate a TLS certificate for `foo.example.org` that the browser on your machine will accept.
+Finally, set the value of `host_identity` in your config file to `foo.example.org` (or whatever), and set `https.cert` and `https.key` to point to your TLS certificate and key files.
+
+Another approach is setting up a reverse proxy on your development machine.
+There are other solutions, as well, to setting up a local origin that your browser will accept as secure.
+
 
 ## Use
 
@@ -39,7 +61,7 @@ The following environment variables are read:
 * NODE_ENV
 
 For production, you should set the environment variable `NODE_ENV` to `production` and configure systemd (or your OS's equivalent) to start and re-start Armadietto.
-See [the systemd docs](../contrib/systemd/README.md).
+See [the systemd notes](../contrib/systemd/README.md).
 
 To add Express modules (such as [express-rate-limit](https://www.npmjs.com/package/express-rate-limit)), edit `bin/www` and `lib/appFactory.js`, or write your own scripts.
 

--- a/notes/reverse-proxy-configuration.md
+++ b/notes/reverse-proxy-configuration.md
@@ -3,7 +3,7 @@
 1. [optional] Set a DNS A record for a new domain name, if Armadietto will appear as a different host than other websites served by your reverse proxy.
 2. Ensure your TLS certificate includes the domain name Armadietto be will visible as.
 3. [optional] Set up a name-based virtual server, if Armadietto will appear as a different host than other websites served by your reverse proxy.
-4. Configure your reverse proxy, and have it set the header `x-forwarded-proto` (or `x-forwarded-ssl` or `x-forwarded-scheme`) in the request passed to Armadietto. Armadietto does not yet support the `Forwarded` header, nor the PROXY protocol. For Apache, the directives are `ProxyPass`, `ProxyPassReverse`, and `RequestHeader`. For Apache, a name-based virtual server and reverse proxy will resemble:
+4. Configure your reverse proxy, and have it set the header `x-forwarded-proto` (or `x-forwarded-ssl` or `x-forwarded-scheme`) in the request passed to Armadietto. Armadietto does not yet support the `Forwarded` header, nor the PROXY protocol. For Apache, the directives are `ProxyPass`, `ProxyPassReverse`, and `RequestHeader`. If the proxy is running on a different host than Armadietto, you must also set the `X-Forwarded-Host` header. For Apache, a name-based virtual server and reverse proxy on the same host will resemble:
 ```
 <VirtualHost *:443>
 ServerName storage.example.com
@@ -21,7 +21,7 @@ RequestHeader unset x-forwarded-scheme
 RequestHeader unset x-forwarded-host
 </VirtualHost>
 ```
-For nginx, a name-based virtual server and reverse proxy will resemble
+For nginx, a name-based virtual server and reverse proxy on the same host will resemble
 ```
 server {
     server_name storage.example.com
@@ -50,7 +50,7 @@ server {
 
 ```
 5. Run `armadietto -e` to see a sample configuration file.
-6. Create a configuration file at `/etc/armadietto/conf.json` (or elsewhere). See README.md for values and their meanings.
+6. Create a configuration file at `/etc/armadietto/conf.json` (or elsewhere). See [the modular-server-specific documentation](../notes/modular-server.md) or [the monolithic-server-specific documentation](../notes/monolithic-server.md) for values.
 7. Run `armadietto -c /etc/armadietto/conf.json` or configure systemd (or the equivalent in your OS) to run armadietto.  See [the systemd docs](../contrib/systemd/README.md).
 
 Don't use shell scripts nor `nodemon` to keep Armadietto running.


### PR DESCRIPTION
The modular server uses Passkeys and the Web Authentication API.  This requires a secure origin.

To serve from the local machine using HTTPS, one approach is to use `mkcert`, which is documented here.
Other approaches are possible.  PRs documenting them would be much appreciated.