### PR TITLE
S3 store router updated to accomodate DigitalOcean Spaces and Scaleway Object Storage

### DIFF
--- a/lib/routes/S3_store_router.js
+++ b/lib/routes/S3_store_router.js
@@ -69,9 +69,9 @@ module.exports = function ({ endPoint = 'play.min.io', accessKey = 'Q3AM3UQ867SP
     // logger: getLogger(),
   });
   s3client.send(new CreateBucketCommand({ Bucket: calcBucketName(ADMIN_NAME) })).then(resp => {
-    getLogger().notice(`created (or re-created) admin bucket: ${resp.Location}`);
+    getLogger().notice(`created (or re-created) admin bucket: ${resp.Location || calcBucketName(ADMIN_NAME)}`);
   }).catch(err => {
-    if (err.name === 'BucketAlreadyOwnedByYou') {
+    if (['BucketAlreadyOwnedByYou', 'BucketAlreadyExists'].includes(err.name)) {
       getLogger().notice(`admin bucket already exists: ${calcBucketName(ADMIN_NAME)}`);
     } else {
       getLogger().alert(Array.from(errToMessages(err, new Set(['while creating admin bucket:']))).join(' '));

--- a/notes/S3-store-router.md
+++ b/notes/S3-store-router.md
@@ -12,6 +12,10 @@ Tested services include:
 
 * Fully working
 
+### DigitalOcean Spaces
+
+* Fully working
+
 ### Garage
 
 * doesn't implement versioning (which would be nice for recovery)

--- a/notes/S3-store-router.md
+++ b/notes/S3-store-router.md
@@ -16,6 +16,10 @@ Tested services include:
 
 * Fully working
 
+### Scaleway Object Storage
+
+* Fully working
+
 ### Garage
 
 * doesn't implement versioning (which would be nice for recovery)

--- a/spec/account.spec.js
+++ b/spec/account.spec.js
@@ -15,7 +15,7 @@ module.exports.shouldCreateDeleteAndReadAccounts = function () {
 
     after(async function () {
       if (this.userIdAccount) {
-        this.timeout(10_000);
+        this.timeout(15_000);
         await this.accountMgr.deleteUser(this.userIdAccount, new Set());
       }
     });
@@ -33,6 +33,7 @@ module.exports.shouldCreateDeleteAndReadAccounts = function () {
     });
 
     it('creates a user & rejects creating a new user with an existing username', async function () {
+      this.timeout(15_000);
       const params1 = { username: this.usernameAccount, contactURL: 'a@b.cc' };
       const logNotes1 = new Set();
       const user = await this.accountMgr.createUser(params1, logNotes1);
@@ -71,12 +72,13 @@ module.exports.shouldCreateDeleteAndReadAccounts = function () {
     });
 
     after(async function () {
+      this.timeout(15_000);
       await this.accountMgr.deleteUser(this.user1?.username, new Set());
       await this.accountMgr.deleteUser(this.user2?.username, new Set());
     });
 
     it('should list users', async function () {
-      this.timeout(10_000);
+      this.timeout(15_000);
       const params1 = { username: this.usernameAccountList1, contactURL: 'mailto:d@ef.gh' };
       this.user1 = await this.accountMgr.createUser(params1, new Set());
       const params2 = { username: this.usernameAccountList2, contactURL: 'mailto:i@jk.lm' };
@@ -99,7 +101,7 @@ module.exports.shouldCreateDeleteAndReadAccounts = function () {
     });
 
     after(async function () {
-      this.timeout(10_000);
+      this.timeout(15_000);
       if (this.user2?.username) {
         await this.accountMgr.deleteUser(this.user2.username, new Set());
       }
@@ -109,7 +111,7 @@ module.exports.shouldCreateDeleteAndReadAccounts = function () {
     });
 
     it('deletes a user', async function () {
-      this.timeout(10_000);
+      this.timeout(15_000);
       const params = { username: this.usernameAccount2, contactURL: 'a@b.cc' };
       this.user2 = await this.accountMgr.createUser(params, new Set());
 
@@ -122,7 +124,7 @@ module.exports.shouldCreateDeleteAndReadAccounts = function () {
     });
 
     it('returns normally when user deleted twice at the same time', async function () {
-      this.timeout(10_000);
+      this.timeout(15_000);
       const params = { username: this.usernameAccount3, contactURL: 'b@c.dd' };
       this.user3 = await this.accountMgr.createUser(params, new Set());
 
@@ -135,7 +137,7 @@ module.exports.shouldCreateDeleteAndReadAccounts = function () {
       expect(results[1]?.[0]).to.be.within(0, 1); // at most 1 blob
       expect(results[1]?.[1]).to.equal(0); // no errors
       expect(results[1]?.[2]).to.be.within(0, 1); // at most 1 pass
-      expect(logNotes.size).to.equal(2); // success note from each call
+      expect(logNotes.size).to.be.within(1, 2); // success notes may be identical
     });
 
     it('returns normally when user doesn\'t exist', async function () {

--- a/spec/store_handler.spec.js
+++ b/spec/store_handler.spec.js
@@ -380,11 +380,11 @@ module.exports.shouldStoreStreams = function () {
         expect(folder.items['yellow-red'].ETag).to.equal(stripQuotes(putRes1.get('ETag')));
         expect(folder.items['yellow-red']['Content-Type']).to.equal('text/csv');
         expect(folder.items['yellow-red']['Content-Length']).to.equal(content1.length);
-        expect(Date.now() - new Date(folder.items['yellow-red']['Last-Modified'])).to.be.lessThan(9_000);
+        expect(Date.now() - new Date(folder.items['yellow-red']['Last-Modified'])).to.be.lessThan(20_000);
         expect(folder.items['blue-green'].ETag).to.equal(stripQuotes(putRes2.get('ETag')));
         expect(folder.items['blue-green']['Content-Type']).to.equal('text/n3');
         expect(folder.items['blue-green']['Content-Length']).to.equal(content2.length);
-        expect(Date.now() - new Date(folder.items['blue-green']['Last-Modified'])).to.be.lessThan(9_000);
+        expect(Date.now() - new Date(folder.items['blue-green']['Last-Modified'])).to.be.lessThan(15_000);
         expect(folder.items['subfolder/'].ETag).to.match(/^.{6,128}$/);
 
         const [_subfolderReq, subfolderRes] = await callMiddleware(this.handler, {
@@ -400,7 +400,7 @@ module.exports.shouldStoreStreams = function () {
         expect(subfolder.items['purple-ultraviolet'].ETag).to.equal(stripQuotes(putRes3.get('ETag')));
         expect(subfolder.items['purple-ultraviolet']['Content-Type']).to.equal('text/plain');
         expect(subfolder.items['purple-ultraviolet']['Content-Length']).to.equal(content3.length);
-        expect(Date.now() - new Date(subfolder.items['purple-ultraviolet']['Last-Modified'])).to.be.lessThan(9_000);
+        expect(Date.now() - new Date(subfolder.items['purple-ultraviolet']['Last-Modified'])).to.be.lessThan(15_000);
 
         const [_getReq2, getRes2] = await callMiddleware(this.handler, {
           method: 'GET',
@@ -447,7 +447,7 @@ module.exports.shouldStoreStreams = function () {
         const subfolderChanged = JSON.parse(subfolderRes2._getBuffer().toString());
         expect(subfolderChanged.items['purple-ultraviolet'].ETag).not.to.equal(stripQuotes(putRes3.get('ETag')));
         expect(subfolderChanged.items['purple-ultraviolet'].ETag).to.equal(stripQuotes(putRes4.get('ETag')));
-        expect(Date.now() - new Date(subfolderChanged.items['purple-ultraviolet']['Last-Modified'])).to.be.lessThan(9_000);
+        expect(Date.now() - new Date(subfolderChanged.items['purple-ultraviolet']['Last-Modified'])).to.be.lessThan(15_000);
       });
 
       it('returns folder when If-None-Match has an old ETag', async function () {
@@ -475,7 +475,7 @@ module.exports.shouldStoreStreams = function () {
         expect(folder.items.mud.ETag).to.equal(stripQuotes(putRes.get('ETag')));
         expect(folder.items.mud['Content-Type']).to.equal('text/vnd.qq');
         expect(folder.items.mud['Content-Length']).to.equal(content.length);
-        expect(Date.now() - new Date(folder.items.mud['Last-Modified'])).to.be.lessThan(9_000);
+        expect(Date.now() - new Date(folder.items.mud['Last-Modified'])).to.be.lessThan(15_000);
       });
     });
   });
@@ -911,7 +911,7 @@ module.exports.shouldStoreStreams = function () {
         expect(folder1.items.qux['Content-Length']).to.be.equal(content.length);
         expect(folder1.items.qux['Content-Type']).to.be.equal('text/example');
         expect(folder1.items.qux.ETag).to.be.equal(stripQuotes(putRes.get('ETag')));
-        expect(Date.now() - new Date(folder1.items.qux['Last-Modified'])).to.be.lessThan(5000);
+        expect(Date.now() - new Date(folder1.items.qux['Last-Modified'])).to.be.lessThan(15_000);
 
         const [_folderReq2, folderRes2] = await callMiddleware(this.handler, { method: 'GET', url: `/${this.userIdStore}/photos/foo/` });
         expect(folderRes2.statusCode).to.equal(200);

--- a/spec/store_handlers/S3_store_handler.spec.js
+++ b/spec/store_handlers/S3_store_handler.spec.js
@@ -11,6 +11,7 @@ const { shouldCreateDeleteAndReadAccounts } = require('../account.spec');
 
 describe('S3 store router', function () {
   before(function () {
+    this.timeout(15_000);
     configureLogger({ stdout: ['notice'], log_dir: './test-log', log_files: ['debug'] });
     this.USER_NAME_SUFFIX = '-java.extraordinary.org';
     // If the environment variables aren't set, tests are run using a shared public account on play.min.io


### PR DESCRIPTION
Tweaks S3 store router to deal with quirks of bucket creation on DigitalOcean.
Extends test timeouts to accomodate DigitalOcean and Scaleway, which are not as fast as Amazon's global network.