### PR TITLE
Express server: fixes bug listing folder, tweaks to aid spec testing & advertises passkey management endpoint

### DIFF
--- a/lib/routes/S3_store_router.js
+++ b/lib/routes/S3_store_router.js
@@ -268,7 +268,7 @@ module.exports = function ({ endPoint = 'play.min.io', accessKey = 'Q3AM3UQ867SP
           const grandparentPath = dirname(folderPath) === '.' ? '' : dirname(folderPath) + '/';
           const grandparent = folders.get(grandparentPath);
           if (grandparent?.[basename(folderPath)]) { // document that can't co-exist with folder
-            grandparent[basename(folderPath)] = undefined; // removes the false document entry
+            delete grandparent[basename(folderPath)]; // removes the false document entry
           }
         }
         if (Array.from(cachedFolders).some(cachedFolderPath => folderPath.startsWith(cachedFolderPath))) {
@@ -288,7 +288,7 @@ module.exports = function ({ endPoint = 'play.min.io', accessKey = 'Q3AM3UQ867SP
       // If Content-Type was not retrieved from 0-byte blob cache, launches a HEAD request for it.
       outerLoop: for (const [folderPath, items] of folders) { // eslint-disable-line no-labels
         for (const [name, metadata] of Object.entries(items)) {
-          if (name.endsWith('/') || metadata['Content-Type'] || TYPE_SUFFIX_PATT.test(name)) {
+          if (name.endsWith('/') || metadata?.['Content-Type'] || TYPE_SUFFIX_PATT.test(name)) {
             continue;
           }
 
@@ -304,9 +304,12 @@ module.exports = function ({ endPoint = 'play.min.io', accessKey = 'Q3AM3UQ867SP
           const itemS3Path = posix.join(s3Path, folderPath, name);
           const metadataPromise = getMetadata(bucketName, itemS3Path, logNotes)
             .then(metadata => {
-              items[name] = metadata;
+              if (metadata) {
+                items[name] = metadata;
+              }
             }).catch(err => {
               incompleteFolders.add(folderPath);
+              errToMessages(err, logNotes);
               throw err;
             });
           metadataPromises.push(metadataPromise);
@@ -459,9 +462,7 @@ module.exports = function ({ endPoint = 'play.min.io', accessKey = 'Q3AM3UQ867SP
         'Content-Length': headResult.ContentLength,
         'Last-Modified': headResult.LastModified?.toUTCString()
       };
-    }).catch(
-      err => errToMessages(err, logNotes)
-    );
+    });
   }
 
   router.put('/:username/*',
@@ -866,7 +867,7 @@ module.exports = function ({ endPoint = 'play.min.io', accessKey = 'Q3AM3UQ867SP
         acceptRanges: headResponse.AcceptRanges
       };
     } catch (err) {
-      if (err.name === 'NotFound' || err.$metadata.httpStatusCode === 404) {
+      if (err.name === 'NotFound' || err.$metadata?.httpStatusCode === 404) {
         throw new NoSuchBlobError(`${path} does not exist`);
       } else {
         throw err;

--- a/lib/routes/storage_common.js
+++ b/lib/routes/storage_common.js
@@ -42,7 +42,7 @@ module.exports = function (hostIdentity, jwtSecret) {
         res.set('Cache-Control', 'public, no-cache');
         next('route'); // allows access without checking JWT
       } else {
-        res.set('Cache-Control', 'private, no-cache');
+        res.set('Cache-Control', 'no-cache');
         next();
       }
     },

--- a/lib/routes/webfinger.js
+++ b/lib/routes/webfinger.js
@@ -86,4 +86,9 @@ function webfinger (req, res) {
   }
 }
 
+router.get('/passkey-endpoints', cors(), passkeyEndpoints);
+function passkeyEndpoints (req, res) {
+  res.type('application/json').json({ manage: getHostBaseUrl(req) + '/account/' });
+}
+
 module.exports = router;

--- a/lib/util/corsMiddleware.js
+++ b/lib/util/corsMiddleware.js
@@ -5,5 +5,5 @@ module.exports = {
     res.set('Access-Control-Allow-Private-Network', 'true');
     next();
   },
-  corsRS: cors({ origin: true, allowedHeaders: 'Content-Type, Authorization, Content-Length, If-Match, If-None-Match, Origin, X-Requested-With', methods: 'GET, HEAD, PUT, DELETE', exposedHeaders: 'ETag', credentials: true, maxAge: 7200 })
+  corsRS: cors({ origin: true, allowedHeaders: 'Content-Type, Authorization, Content-Length, If-Match, If-None-Match, Origin, X-Requested-With', methods: 'OPTIONS, GET, HEAD, PUT, DELETE', exposedHeaders: 'ETag', credentials: true, maxAge: 7200 })
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "armadietto",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "armadietto",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.523.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "decentralization"
   ],
   "license": "MIT",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "engines": {
     "node": ">=20.0"
   },

--- a/spec/modular/m_web_finger.spec.js
+++ b/spec/modular/m_web_finger.spec.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha, chai, node */
+/* eslint-disable no-unused-expressions */
 
 const { mockAccountFactory } = require('../util/mockAccount');
 const http = require('http');
@@ -42,5 +43,14 @@ describe('Web Finger (modular)', function () {
   it('redirects change-password to /signup', async function () {
     const res = await chai.request(this.app).get('/.well-known/change-password');
     expect(res).to.redirectTo(/^http:\/\/127.0.0.1:\d{1,5}\/signup$/);
+  });
+
+  it('advertises passkey management endpoint', async function () {
+    const res = await chai.request(this.app).get('/.well-known/passkey-endpoints');
+    expect(res).to.have.status(200);
+    expect(res).to.have.header('Strict-Transport-Security', /^max-age=\d{8,9}/);
+    expect(res).to.be.json;
+    expect(res).to.have.charset('utf-8');
+    expect(res.body.manage).to.match(/^http:\/\/127.0.0.1:\d{1,5}\/account\/$/);
   });
 });

--- a/spec/storage_common.spec.js
+++ b/spec/storage_common.spec.js
@@ -48,6 +48,7 @@ module.exports.shouldCrudBlobs = function () {
       expect(res.get('Access-Control-Allow-Methods')).to.contain('HEAD');
       expect(res.get('Access-Control-Allow-Methods')).to.contain('PUT');
       expect(res.get('Access-Control-Allow-Methods')).to.contain('DELETE');
+      expect(res.get('Access-Control-Allow-Methods')).to.contain('OPTIONS');
       expect(res.get('Access-Control-Allow-Methods')).not.to.contain('POST');
       expect(res.get('Access-Control-Allow-Methods')).not.to.contain('PATCH');
       expect(res.get('Access-Control-Expose-Headers')).to.contain('ETag');

--- a/spec/store_handler.spec.js
+++ b/spec/store_handler.spec.js
@@ -19,8 +19,6 @@ const ADMIN_INVITE_DIR_NAME = 'invites';
 const LIST_DIR_NAME = 'stuff-' + Math.round(Math.random() * Number.MAX_SAFE_INTEGER);
 
 module.exports.shouldStoreStreams = function () {
-  this.timeout(60_000);
-
   before(async function () {
     const usernameStore = ('automated-test-' + Math.round(Math.random() * Number.MAX_SAFE_INTEGER)).slice(0, 29);
     const user = await this.store.createUser({ username: usernameStore, contactURL: 'l@m.no' }, new Set());
@@ -33,6 +31,8 @@ module.exports.shouldStoreStreams = function () {
   });
 
   describe('upsertAdminBlob & readAdminBlob', function () {
+    this.timeout(60_000);
+
     it('should store and retrieve blobs', async function () {
       const relativePath = path.join(ADMIN_INVITE_DIR_NAME, 'mailto%3Atestname%40testhost.org.yaml');
       const value = { foo: 'bar', spam: [42, 69, 'hut', 'hut', 'hike!'] };
@@ -47,6 +47,8 @@ module.exports.shouldStoreStreams = function () {
   });
 
   describe('metadataAdminBlob', function () {
+    this.timeout(60_000);
+
     it('should retrieve metadata', async function () {
       const relativePath = path.join(ADMIN_INVITE_DIR_NAME, 'mailto%3Asomename%40somehost.edu.yaml');
       const content = YAML.stringify({ frotz: 'frell' });
@@ -87,6 +89,8 @@ module.exports.shouldStoreStreams = function () {
   });
 
   describe('listAdminBlobs', function () {
+    this.timeout(60_000);
+
     it('should list blobs', async function () {
       const blobs = await this.handler.listAdminBlobs(LIST_DIR_NAME);
       expect(blobs).to.have.length(0);
@@ -118,6 +122,8 @@ module.exports.shouldStoreStreams = function () {
   });
 
   describe('GET', function () {
+    this.timeout(60_000);
+
     describe('for files', function () {
       describe('unversioned', function () {
         it('returns Not Found for a non-existing user', async function () {
@@ -511,6 +517,8 @@ module.exports.shouldStoreStreams = function () {
   });
 
   describe('PUT', function () {
+    this.timeout(60_000);
+
     describe('unversioned', function () {
       it('does not create a file for a bad user name', async function () {
         const content = 'microbe';
@@ -934,10 +942,12 @@ module.exports.shouldStoreStreams = function () {
         ]);
 
         expect(resLong.statusCode).to.be.oneOf([201, 409, 429, 503]);
+        if ([429, 503].includes(resLong.statusCode)) console.warn('first simultaneous create (long) got busy response');
         expect(resLong._getBuffer().toString()).to.equal('');
         expect(nextLong).not.to.have.been.called();
 
         expect(resShort.statusCode).to.be.oneOf([201, 409, 429, 503]);
+        if ([429, 503].includes(resShort.statusCode)) console.warn('second simultaneous create (short) got busy response');
         expect(resShort._getBuffer().toString()).to.equal('');
         expect(nextShort).not.to.have.been.called();
 
@@ -1402,6 +1412,8 @@ module.exports.shouldStoreStreams = function () {
   });
 
   describe('DELETE', function () {
+    this.timeout(60_000);
+
     describe('unversioned', function () {
       it('should return Not Found for nonexistent user', async function () {
         const [_req, res, next] = await callMiddleware(this.handler, {
@@ -1664,5 +1676,5 @@ module.exports.shouldStoreStreams = function () {
 };
 
 function stripQuotes (ETag) {
-  return ETag.replace(/^"|^W\/"|"$/g, '');
+  return ETag?.replace(/^"|^W\/"|"$/g, '');
 }

--- a/spec/store_handler.spec.js
+++ b/spec/store_handler.spec.js
@@ -513,6 +513,21 @@ module.exports.shouldStoreStreams = function () {
         expect(newFolder).to.deep.equal(folder);
         expect(logNotes.size).to.equal(1);
       });
+
+      it('returns listing for root folder', async function () {
+        const [_req, res, next] = await callMiddleware(this.handler, {
+          method: 'GET',
+          url: `/${this.userIdStore}/`
+        });
+
+        expect(res.statusCode).to.equal(200);
+        expect(res.get('Content-Type')).to.equal('application/ld+json');
+        const rootFolder = res._getJSONData();
+        expect(rootFolder['@context']).to.equal('http://remotestorage.io/spec/folder-description');
+        expect(Object.getPrototypeOf(rootFolder.items)).to.equal(Object.prototype);
+        expect(res.get('ETag')).to.match(/^"[#-~!]{6,128}"$/);
+        expect(next).not.to.have.been.called();
+      });
     });
   });
 


### PR DESCRIPTION
Express server: 
1. Fixes streaming storage test timeouts
2. fixes bug listing folder containing document & folder w/ same name
3. allows non-preflight cross-origin OPTIONS requests (useful for checking spec-compliance)
4. /storage/ paths Cache-Control header doesn't contain redundant 'private'
5. advertises passkey management endpoint for password managers