### PR TITLE
GitHub Action pushes to the 'remotestorage' repository on Docker Hub

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -63,8 +63,13 @@ jobs:
       run: docker load --input /tmp/docker.tar
     - name: Run security tests
       continue-on-error: true
-      run: |
-        docker run --rm  -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --exit-code 1 $DOCKER_NAMESPACE/armadietto-monolithic:${{ needs.version.outputs.version }}
+      uses: aquasecurity/trivy-action@v0.35.0
+      with:
+        image-ref: ${{ env.DOCKER_NAMESPACE }}/armadietto-monolithic:${{ needs.version.outputs.version }}
+        format: 'table'
+        exit-code: '1'
+        vuln-type: 'os,library'
+        severity: 'CRITICAL,HIGH,MEDIUM'
   #e2e_test:
   #  runs-on: ubuntu-latest
   #  needs:
@@ -80,7 +85,7 @@ jobs:
   #  - name: Load docker image
   #    run: docker load --input /tmp/docker.tar
   publish:
-    if: github.ref_type == 'tag'
+    if: github.event_name == 'release' || github.ref_type == 'tag'
     runs-on: ubuntu-latest
     needs:
       - version
@@ -94,9 +99,13 @@ jobs:
         path: /tmp
     - name: Load docker image
       run: docker load --input /tmp/docker.tar
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ env.DOCKER_USER }}
+        password: ${{ env.DOCKER_TOKEN }}
     - name: Publish Docker image
       run: |
-        docker login -u $DOCKER_USER -p $DOCKER_TOKEN
         docker push $DOCKER_NAMESPACE/armadietto-monolithic:${{ needs.version.outputs.version }}
         docker tag $DOCKER_NAMESPACE/armadietto-monolithic:${{ needs.version.outputs.version }} $DOCKER_NAMESPACE/armadietto-monolithic
         docker push $DOCKER_NAMESPACE/armadietto-monolithic

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -9,6 +9,13 @@ on:
     tags:
       - '*'
 
+# set these in the GitHub repo .../settings/secrets/actions
+env:
+  DOCKER_USER: ${{ secrets.DOCKER_USER }}
+  DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+  DOCKER_NAMESPACE: ${{ vars.DOCKER_NAMESPACE }}
+  # DOCKER_NAMESPACE may be the same as DOCKER_USER
+
 jobs:
   version:
     runs-on: ubuntu-latest
@@ -25,8 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
      - version
-    env:
-      DOCKER_USER: ${{ secrets.DOCKER_USER }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Docker Buildx
@@ -36,7 +41,7 @@ jobs:
       with:
         context: .
         file: ./docker/Dockerfile-monolithic
-        tags: ${{ env.DOCKER_USER }}/armadietto-monolithic:${{ needs.version.outputs.version }}
+        tags: ${{ env.DOCKER_NAMESPACE }}/armadietto-monolithic:${{ needs.version.outputs.version }}
         outputs: type=docker,dest=/tmp/docker.tar
     - name: Upload artifact
       uses: actions/upload-artifact@v4
@@ -48,8 +53,6 @@ jobs:
     needs:
       - version
       - build
-    env:
-      DOCKER_USER: ${{ secrets.DOCKER_USER }}
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -61,7 +64,7 @@ jobs:
     - name: Run security tests
       continue-on-error: true
       run: |
-        docker run --rm  -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --exit-code 1 remotestorage/armadietto-monolithic:${{ needs.version.outputs.version }}
+        docker run --rm  -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --exit-code 1 $DOCKER_NAMESPACE/armadietto-monolithic:${{ needs.version.outputs.version }}
   #e2e_test:
   #  runs-on: ubuntu-latest
   #  needs:
@@ -83,9 +86,6 @@ jobs:
       - version
       - sec_test
       #- e2e_test
-    env:
-      DOCKER_USER: ${{ secrets.DOCKER_USER }}
-      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
     steps:
     - name: Download artifacts
       uses: actions/download-artifact@v4
@@ -97,6 +97,6 @@ jobs:
     - name: Publish Docker image
       run: |
         docker login -u $DOCKER_USER -p $DOCKER_TOKEN
-        docker push remotestorage/armadietto-monolithic:${{ needs.version.outputs.version }}
-        docker tag remotestorage/armadietto-monolithic:${{ needs.version.outputs.version }} remotestorage/armadietto-monolithic
-        docker push remotestorage/armadietto-monolithic
+        docker push $DOCKER_NAMESPACE/armadietto-monolithic:${{ needs.version.outputs.version }}
+        docker tag $DOCKER_NAMESPACE/armadietto-monolithic:${{ needs.version.outputs.version }} $DOCKER_NAMESPACE/armadietto-monolithic
+        docker push $DOCKER_NAMESPACE/armadietto-monolithic

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Run security tests
       continue-on-error: true
       run: |
-        docker run --rm  -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --exit-code 1 $DOCKER_USER/armadietto-monolithic:${{ needs.version.outputs.version }}
+        docker run --rm  -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image --exit-code 1 remotestorage/armadietto-monolithic:${{ needs.version.outputs.version }}
   #e2e_test:
   #  runs-on: ubuntu-latest
   #  needs:
@@ -97,6 +97,6 @@ jobs:
     - name: Publish Docker image
       run: |
         docker login -u $DOCKER_USER -p $DOCKER_TOKEN
-        docker push $DOCKER_USER/armadietto-monolithic:${{ needs.version.outputs.version }}
-        docker tag $DOCKER_USER/armadietto-monolithic:${{ needs.version.outputs.version }} $DOCKER_USER/armadietto-monolithic
-        docker push $DOCKER_USER/armadietto-monolithic
+        docker push remotestorage/armadietto-monolithic:${{ needs.version.outputs.version }}
+        docker tag remotestorage/armadietto-monolithic:${{ needs.version.outputs.version }} remotestorage/armadietto-monolithic
+        docker push remotestorage/armadietto-monolithic


### PR DESCRIPTION
Why: The image should be available from Docker Hub as "remotestorage/armadietto", regardless of the credentials used with Docker Hub.