### PR TITLE
README: replaces "alpha-quality" warning with "beta-quality" note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # Armadietto [![npm](https://img.shields.io/npm/v/armadietto)](https://www.npmjs.com/package/armadietto) [![Build Status](https://github.com/remotestorage/armadietto/actions/workflows/test-and-lint.yml/badge.svg)](https://github.com/remotestorage/armadietto/actions/workflows/test-and-lint.yml?query=branch%3Amaster)
 
-> ### :warning: WARNING
-> Please do not consider `armadietto` production ready, this project is still
-> considered experimental.  As with any alpha-stage storage technology, you
-> MUST expect that it will eat your data and take precautions against this. You
-> SHOULD expect that its APIs and storage schemas will change before it is
-> labelled stable.
+> [!IMPORTANT]
+> While this project has been used operationally for years,
+> it should be considered beta software.
+> Before using it, check the
+> [current bugs](https://github.com/remotestorage/armadietto/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug)
+> to see if any will affect your installation.
+>
+> Run a test installation to determine if the current feature set meets your needs;
+> you may need to help extend any features important to you.
+>
+> Implement a robust backup system for production,
+> and ramp up usage slowly while monitoring the load on your server(s).
+
 
 ## What is this?
 
@@ -34,9 +41,9 @@ See the `notes` directory for [configuring a reverse proxy](notes/reverse-proxy-
 * Authenticates user with Passkey or "invitation" URL
 * Can run multiple application servers to increase capacity to enterprise-scale
 * Unauthorized clients are rate-limited; an authorized client may use all capacity to back up or restore quickly
-* Bug Fix: correctly handles If-None-Match with ETag
-* Bug Fix: returns empty listing for nonexistent folder
-* Implements current spec: draft-dejong-remotestorage-22
+* Correctly handles If-None-Match with ETag [fix relative to Classic]
+* Returns empty listing for nonexistent folder [fix relative to Classic]
+* Implements recent spec: draft-dejong-remotestorage-22
 
 See [the Express-server-specific documentation](./notes/modular-server.md) for usage.
 
@@ -44,8 +51,9 @@ See [the Express-server-specific documentation](./notes/modular-server.md) for u
 
 * Stores user documents in server file system
 * Authenticates user with password
-* More thoroughly tested
-* Doesn't fully implement spec:
+* Longer history of production use
+* Bug: [restoring a backup of a non-existent file fails](https://github.com/remotestorage/armadietto/issues/164)
+* Doesn't fully implement [spec](https://github.com/remotestorage/spec/blob/main/release/draft-dejong-remotestorage-26.txt):
   * doesn't send the `Last-Modified` header
   * sometimes doesn't send the `Content-Length` header
   * sends incorrect 403 status when Authorization header is missing.
@@ -167,7 +175,7 @@ See [`DEVELOPMENT.md`](./DEVELOPMENT.md)
 (The MIT License)
 
 Copyright © 2012–2015 James Coglan
-Copyright © 2018–2025 remoteStorage contributors
+Copyright © 2018–2026 remoteStorage contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the 'Software'), to deal in

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See the `notes` directory for [configuring a reverse proxy](notes/reverse-proxy-
 
 * Streaming storage (documents don't have to fit in server memory)
 * S3-compatible storage (requires separate S3 server; AWS S3 allows documents up to 5 TB)
-* Authenticates user with Passkey or "invitation" URL
+* Authenticates user with Passkey or "invitation" URL (requires Passkey support on all client devices)
 * Can run multiple application servers to increase capacity to enterprise-scale
 * Unauthorized clients are rate-limited; an authorized client may use all capacity to back up or restore quickly
 * Correctly handles If-None-Match with ETag [fix relative to Classic]

--- a/notes/modular-server.md
+++ b/notes/modular-server.md
@@ -10,7 +10,7 @@ There's an NPM module for almost anything worth doing in a Node.js server (albei
 
 ### S3-compatible storage
 
-In addition to installing Armadietto, you **MUST** have a server  with an S3-compatible interface.
+Before installing Armadietto, you **MUST** have a server with an S3-compatible interface.
 If your hosting provider doesn't offer S3-compatible storage as a service, you can self-host using any of several open-source servers, on the same machine as Armadietto if you like.
 
 See [S3-compatible Streaming Store](S3-store-router.md) for compatability of various implementations.
@@ -116,7 +116,10 @@ You *MUST* set `app.locals.title` and `app.locals.signup` or the web pages won't
 
 ## Multiple instances of the modular server
 
-Sessions are stored in memory, so your load balancer must use sticky sessions (session affinity), for `/admin`, `/account` and `/oauth` paths.
+Sessions are stored in memory, so your load balancer **must** use sticky sessions (session affinity), for everything under the `/admin`, `/account` and `/oauth` paths.
+
+Other paths **should not** use sticky sessions (session affinity), so the load is evenly distributed across the instances.
+As requests may vary greatly in size, least-connections or random-two are probably better load-balancing algorithms than round-robin.
 
 ## Proxies
 
@@ -136,6 +139,8 @@ Contact URLs are used to identify users, when issuing invitations. Ideally, it s
 Armadietto can't send invitations itself yet; an admin must send the invitation manually, using their own account.  The Armadietto user interface allows you to send the invite via the system share functionality, or copy and paste from the user interface.
 You can send the invite by any means; it's not required that you use the contact info in the Contact URL.
 For example, you could send an invite to a person in the same room, using AirDrop or Nearby Share, or save the invite in a file drop.
+
+For each ecosystem of devices that share Passkeys (Apple Keychain, Windows Hello, Google Password Manager, YubiKey, etc.) and each browser not part of an ecosystem, a separate Passkey must be generated, and thus a separate invite must be sent.  After the first invite, users can create the other invites themselves.
 
 If `allow_signup` is set in the configuration file, anyone can *request* an invite.
 Admins can list these requests and grant them.


### PR DESCRIPTION
Fixes https://github.com/remotestorage/armadietto/issues/163

Also clarifies differences between Classic and Express servers, and updates copyright.